### PR TITLE
fix(form): when loading instantly failed, then cancel label wasn't shown

### DIFF
--- a/projects/components/form/src/form.component.spec.ts
+++ b/projects/components/form/src/form.component.spec.ts
@@ -209,7 +209,9 @@ describe('PsFormComponent', () => {
       expect(getSavebarCard(fixture)).toBe(null);
       expect(getErrorContainer(fixture)).not.toBe(null);
       expect(getErrorIcon(fixture)).not.toBe(null);
-      expect(getErrorActions(fixture)).not.toBe(null);
+      const errorActionBar = getErrorActions(fixture);
+      expect(errorActionBar).not.toBe(null);
+      expect(errorActionBar.query(By.css('.mat-button-wrapper')).nativeElement.textContent.trim()).toBe('Cancel');
     }));
 
     it('should show error bar when saving failed', fakeAsync(() => {
@@ -418,17 +420,19 @@ describe('PsFormComponent', () => {
   describe('isolated', () => {
     let actionService: PsFormActionService;
     let errorExtractor: PsExceptionMessageExtractor;
+    let intlService: PsSavebarIntl;
     let route: ActivatedRoute;
     let cd: ChangeDetectorRef;
     let component: PsFormComponent;
     beforeEach(async(() => {
       actionService = new DemoPsFormActionService();
+      intlService = new PsSavebarIntlEn();
       errorExtractor = new PsExceptionMessageExtractor();
       route = {} as any;
       cd = {
         markForCheck: () => {},
       } as ChangeDetectorRef;
-      component = new PsFormComponent(actionService, errorExtractor, route, cd);
+      component = new PsFormComponent(actionService, intlService, errorExtractor, route, cd);
       component.form = new FormGroup({});
       component.formMode = 'update';
       component.loadFnc = () => of({});

--- a/projects/components/savebar/src/savebar.intl.ts
+++ b/projects/components/savebar/src/savebar.intl.ts
@@ -18,6 +18,16 @@ export abstract class PsSavebarIntl implements IPsSavebarIntlTexts {
   public abstract cancelLabel: string;
   public abstract nextLabel: string;
   public abstract prevLabel: string;
+
+  public mergeIntl(overrides: IPsSavebarIntlTexts): IPsSavebarIntlTexts {
+    return {
+      saveLabel: (overrides && overrides.saveLabel) || this.saveLabel,
+      saveAndCloseLabel: (overrides && overrides.saveAndCloseLabel) || this.saveAndCloseLabel,
+      cancelLabel: (overrides && overrides.cancelLabel) || this.cancelLabel,
+      nextLabel: (overrides && overrides.nextLabel) || this.nextLabel,
+      prevLabel: (overrides && overrides.prevLabel) || this.prevLabel,
+    };
+  }
 }
 
 export class PsSavebarIntlEn extends PsSavebarIntl {


### PR DESCRIPTION
The savebar ViewChild wasn't resolved yet in this case, so the intl property evaluated to an empty
object