### PR TITLE
fix(form-field): async checkbox labels in the template are overwritten

### DIFF
--- a/projects/components/form-field/src/form-field.component.ts
+++ b/projects/components/form-field/src/form-field.component.ts
@@ -193,7 +193,11 @@ export class PsFormFieldComponent implements AfterContentInit, OnDestroy {
       if (this.controlType.startsWith('mat-checkbox')) {
         const labelNode = this._elementRef.nativeElement.querySelectorAll('.mat-checkbox-label')[0];
         if (!labelNode.innerText.trim()) {
-          labelNode.innerText = label;
+          if (labelNode.childNodes.length === 1) {
+            labelNode.appendChild(document.createTextNode(label));
+          } else {
+            labelNode.childNodes[1].nodeValue = label;
+          }
         }
       } else {
         this.calculatedLabel = label;

--- a/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.ts
+++ b/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ViewEncapsulation } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
+import { of } from 'rxjs';
 
 @Component({
   selector: 'app-reference-column',
@@ -128,7 +129,7 @@ export class ReferenceColumnComponent {
           </div>
           <div>
             <ps-form-field hint="hint text">
-              <mat-checkbox formControlName="Checkbox">Custom Label</mat-checkbox>
+              <mat-checkbox formControlName="Checkbox">{{ asyncLabel$ | async }}</mat-checkbox>
             </ps-form-field>
           </div>
           <div>
@@ -162,6 +163,7 @@ export class ReferenceColumnComponent {
   encapsulation: ViewEncapsulation.None,
 })
 export class FormFieldDemoComponent {
+  public asyncLabel$ = of('Custom Label');
   public ctrlCountNumbers = Array(7).fill(1);
   public value = '';
   public get disabled(): boolean {


### PR DESCRIPTION
The check for an existing checkbox label didn't account for labels set with an async pipe and also
deleted the text node where angular wanted to set the label text when it was resolved. Now the text
node will be updated instead of overwritten, so angular can revert the label if it is set with an
async pipe.