### PR TITLE
fix(block-ui): spinner position is now in the middle in more cases

### DIFF
--- a/projects/components/block-ui/src/block-ui.component.ts
+++ b/projects/components/block-ui/src/block-ui.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, ElementRef, Input, OnChanges, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  Input,
+  OnChanges,
+  ViewChild,
+  ViewEncapsulation,
+  AfterViewInit,
+} from '@angular/core';
 
 @Component({
   selector: 'ps-block-ui',
@@ -8,7 +17,7 @@ import { ChangeDetectionStrategy, Component, ElementRef, Input, OnChanges, ViewC
     </div>
     <ng-container *ngIf="blocked">
       <div class="ps-block-ui__overlay">
-        <div class="ps-block-ui__overlay-content" [style.top]="overlayContentTop">
+        <div class="ps-block-ui__overlay-content">
           <mat-spinner class="ps-block-ui__spinner" [diameter]="spinnerDiameter"></mat-spinner>
           <div *ngIf="spinnerText">{{ spinnerText }}</div>
         </div>
@@ -32,40 +41,53 @@ import { ChangeDetectionStrategy, Component, ElementRef, Input, OnChanges, ViewC
         grid-row: 1;
         z-index: 2;
         background-color: rgba(244, 244, 244, 0.6);
+
+        display: flex;
+        justify-content: center;
+        align-items: center;
       }
 
       .ps-block-ui__spinner {
+        display: inline-block;
+        margin: auto;
         color: var(--ps-primary);
         opacity: 1;
       }
 
       .ps-block-ui__overlay-content {
         text-align: center;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-items: center;
+
         position: sticky;
+        top: 10%;
+        bottom: 10%;
       }
     `,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class PsBlockUiComponent implements OnChanges {
+export class PsBlockUiComponent implements OnChanges, AfterViewInit {
   @Input() public blocked: boolean;
   @Input() public spinnerText: string;
 
   public spinnerDiameter = 100;
-  public overlayContentTop = 'calc(50% - 50px)';
 
   @ViewChild('content', { static: true }) public contentNode: ElementRef<HTMLElement>;
 
   public ngOnChanges() {
+    if (this.blocked) {
+      this.updateSpinner();
+    }
+  }
+
+  public ngAfterViewInit() {
+    this.updateSpinner();
+  }
+
+  private updateSpinner() {
     const nativeEl = this.contentNode.nativeElement;
     const minDimension = Math.min(nativeEl.offsetWidth, nativeEl.offsetHeight);
     const textSpace = this.spinnerText ? 20 : 0;
     this.spinnerDiameter = Math.max(Math.min(minDimension - textSpace, 100), 10);
-    this.overlayContentTop = `calc(50% - ${Math.floor(this.spinnerDiameter / 2)}px)`;
   }
 }

--- a/projects/prosoft-components-demo/src/app/block-ui-demo/block-ui-demo.component.ts
+++ b/projects/prosoft-components-demo/src/app/block-ui-demo/block-ui-demo.component.ts
@@ -15,7 +15,7 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
     </ps-block-ui>
     <div style="height: 1em;"></div>
     <ps-block-ui [blocked]="blocked" [spinnerText]="spinnerText">
-      <mat-card style="height: 100px">
+      <mat-card style="height: 30vh">
         this will also be blocked
       </mat-card>
     </ps-block-ui>
@@ -39,5 +39,5 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 })
 export class BlockUiDemoComponent {
   public blocked = true;
-  public spinnerText = 'some custom text';
+  public spinnerText = 'some custom text that will be displayed while the view is blocked';
 }


### PR DESCRIPTION
Before the spinner was in the middle of the screen within the bounds of the blocked component. Now
it is in the middle of the component but tries to stay within the visible screen area.