### PR TITLE
style(slider): slider now shows "grab" and "grabbing" cursor

### DIFF
--- a/projects/components/slider/src/slider.component.scss
+++ b/projects/components/slider/src/slider.component.scss
@@ -26,6 +26,9 @@ ps-slider {
     border-color: var(--ps-primary);
     box-shadow: none;
     transform: translate(-50%, 30%);
+    &:hover {
+      cursor: grab;
+    }
 
     &::after {
       content: unset;
@@ -49,6 +52,11 @@ ps-slider {
 
   .noUi-active .noUi-tooltip {
     display: block;
+    cursor: grabbing;
+  }
+
+  .noUi-active {
+    cursor: grabbing;
   }
 
   &.ps-slider-invalid {


### PR DESCRIPTION
When hovering a handle the cursor now shows grab. When clicking and draging the cursor now shows
grabbing.

fix #35