### PR TITLE
style(table): seperated sort direction buttons

### DIFF
--- a/projects/components/table/src/subcomponents/table-sort.component.ts
+++ b/projects/components/table/src/subcomponents/table-sort.component.ts
@@ -45,6 +45,7 @@ import { IPsTableSortDefinition } from '../models';
         height: 28px;
         line-height: 28px;
         margin-top: 16px;
+        margin-left: 0.2em;
       }
 
       .ps-table-sort__dir-button .mat-button-wrapper {


### PR DESCRIPTION
The sort direction buttons were squased together an were squashed on the mat-select. Every element
is now sepereated by .2em from each other.

fix #36