### PR TITLE
feat(table): current table state can be controlled with a state manager

### DIFF
--- a/projects/components/table/public_api.ts
+++ b/projects/components/table/public_api.ts
@@ -3,6 +3,8 @@ export { IPsTableSortDefinition, IPsTableUpdateDataInfo } from './src/models';
 export { IPsTableSetting, PsTableSettingsService } from './src/services/table-settings.service';
 export { PsTableComponent } from './src/table.component';
 export { PsTableModule } from './src/table.module';
+export { PsTableMemoryStateManager, PsTableUrlStateManager, PsTableStateManager } from './src/helper/state-manager';
+export { PsTableColumnDirective } from './src/directives/table.directives';
 
 // reexport
 export { IPsTableIntlTexts } from '@prosoft/components/core';

--- a/projects/components/table/src/helper/state-manager.spec.ts
+++ b/projects/components/table/src/helper/state-manager.spec.ts
@@ -1,0 +1,66 @@
+import { IPsTableUpdateDataInfo } from '../models';
+import { PsTableMemoryStateManager, PsTableUrlStateManager } from './state-manager';
+import { Router, ParamMap, convertToParamMap, ActivatedRoute, NavigationExtras } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+
+describe('PsTableStateManager', () => {
+  it('PsTableUrlStateManager', () => {
+    const queryParams$ = new BehaviorSubject<ParamMap>(convertToParamMap({}));
+
+    const mockRouter: any = {
+      navigate: (path: any[], options: NavigationExtras) => {
+        queryParams$.next(convertToParamMap(options.queryParams));
+      },
+    };
+
+    const route: ActivatedRoute = <any>{
+      snapshot: new Proxy(queryParams$, {
+        get: (obj, prop) => {
+          if (prop === 'queryParamMap') {
+            return obj.value;
+          }
+        },
+      }),
+      queryParamMap: queryParams$,
+    };
+    const stateManager = new PsTableUrlStateManager(mockRouter, route);
+    const source$ = stateManager.createStateSource('tableId');
+    const states: IPsTableUpdateDataInfo[] = [];
+    const sub = source$.subscribe(state => {
+      states.push(state);
+    });
+
+    const update1 = createTableUpdateDataInfo();
+    const update2 = createTableUpdateDataInfo();
+
+    stateManager.requestUpdate('tableId', update1);
+    stateManager.requestUpdate('tableId', update2);
+    stateManager.remove('tableId');
+
+    expect(states).toEqual([null, update1, update2, null]);
+    sub.unsubscribe();
+  });
+
+  it('PsTableMemoryStateManager', () => {
+    const stateManager = new PsTableMemoryStateManager();
+    const source$ = stateManager.createStateSource('tableId');
+    const states: IPsTableUpdateDataInfo[] = [];
+    const sub = source$.subscribe(state => {
+      states.push(state);
+    });
+
+    const update1 = createTableUpdateDataInfo();
+    const update2 = createTableUpdateDataInfo();
+
+    stateManager.requestUpdate('tableId', update1);
+    stateManager.requestUpdate('tableId', update2);
+    stateManager.remove('tableId');
+
+    expect(states).toEqual([null, update1, update2, null]);
+    sub.unsubscribe();
+  });
+});
+
+function createTableUpdateDataInfo(): IPsTableUpdateDataInfo {
+  return { currentPage: 0, pageSize: 5, searchText: 'test', sortColumn: 'a', sortDirection: 'asc' };
+}

--- a/projects/components/table/src/helper/state-manager.ts
+++ b/projects/components/table/src/helper/state-manager.ts
@@ -1,0 +1,77 @@
+import { ActivatedRoute, Router } from '@angular/router';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { IPsTableUpdateDataInfo } from '../models';
+import { asQueryParams, fromQueryParams } from './table.helper';
+
+export abstract class PsTableStateManager {
+  abstract remove(tableId: string): void;
+  abstract createStateSource(tableId: string): Observable<IPsTableUpdateDataInfo>;
+  abstract requestUpdate(tableId: string, updateInfo: IPsTableUpdateDataInfo): void;
+}
+
+export class PsTableUrlStateManager extends PsTableStateManager {
+  constructor(private router: Router, private route: ActivatedRoute) {
+    super();
+  }
+
+  public remove(tableId: string) {
+    const currentParams = this.route.snapshot.queryParamMap;
+    const newQueryParams: { [id: string]: any } = {};
+    for (const key of currentParams.keys) {
+      if (key !== tableId) {
+        newQueryParams[key] = currentParams.get(key);
+      }
+    }
+
+    this.router.navigate([], {
+      queryParams: newQueryParams,
+      relativeTo: this.route,
+    });
+  }
+
+  public createStateSource(tableId: string) {
+    return this.route.queryParamMap.pipe(
+      map(queryParamMap => {
+        if (tableId && queryParamMap.has(tableId)) {
+          return fromQueryParams(queryParamMap.get(tableId));
+        }
+        return null;
+      })
+    );
+  }
+
+  public requestUpdate(tableId: string, updateInfo: IPsTableUpdateDataInfo) {
+    const newQueryParams: { [id: string]: any } = {};
+
+    const currentParams = this.route.snapshot.queryParamMap;
+    for (const key of currentParams.keys) {
+      newQueryParams[key] = currentParams.get(key);
+    }
+
+    if (tableId) {
+      newQueryParams[tableId] = asQueryParams(updateInfo);
+    }
+
+    this.router.navigate([], {
+      queryParams: newQueryParams,
+      relativeTo: this.route,
+    });
+  }
+}
+
+export class PsTableMemoryStateManager extends PsTableStateManager {
+  private settings$ = new BehaviorSubject<IPsTableUpdateDataInfo>(null);
+
+  public remove(tableId: string) {
+    this.settings$.next(null);
+  }
+
+  public createStateSource(tableId: string) {
+    return this.settings$.asObservable();
+  }
+
+  public requestUpdate(tableId: string, updateInfo: IPsTableUpdateDataInfo) {
+    this.settings$.next(updateInfo);
+  }
+}


### PR DESCRIPTION
A state manager can now be provided to controll where the table state is stored. Default is
PsTableUrlStateManager but a PsTableMemoryStateManager now also comes with the table.