### PR TITLE
fix(select): values set before AfterViewInit are now working correctly

### DIFF
--- a/projects/components/select/src/select-data.component.spec.ts
+++ b/projects/components/select/src/select-data.component.spec.ts
@@ -188,10 +188,14 @@ describe('PsSelectDataComponent', () => {
     component.ngOnDestroy();
   }));
   it('should pass selectedValue from MatSelect to DataSource', fakeAsync(() => {
+    spyOn(dataSource, 'selectedValuesChanged');
+
+    const initialSelectedValue = { value: 42, label: 'init' };
+    (<FormControl>(<unknown>matSelect.ngControl)).patchValue(initialSelectedValue);
     component.ngAfterViewInit();
+    expect(dataSource.selectedValuesChanged).toHaveBeenCalledWith([initialSelectedValue]);
 
     const newSelectedValue = { value: 1, label: '1' };
-    spyOn(dataSource, 'selectedValuesChanged');
 
     (<FormControl>(<unknown>matSelect.ngControl)).patchValue(newSelectedValue);
     expect(dataSource.selectedValuesChanged).toHaveBeenCalledWith([newSelectedValue]);

--- a/projects/components/select/src/select-data.component.ts
+++ b/projects/components/select/src/select-data.component.ts
@@ -174,9 +174,13 @@ export class PsSelectDataComponent<T = any> implements AfterViewInit, OnDestroy 
     this.filterCtrl.valueChanges
       .pipe(takeUntil(this._ngUnsubscribe$))
       .subscribe(searchText => this.dataSource.searchTextChanged(searchText));
-    this.select.ngControl.valueChanges
-      .pipe(takeUntil(this._ngUnsubscribe$))
-      .subscribe(value => this._pushSelectedValuesToDataSource(value));
+
+    const ngControl = this.select.ngControl;
+    let valueChanges = ngControl.valueChanges;
+    if (ngControl.value) {
+      valueChanges = valueChanges.pipe(startWith(ngControl.value));
+    }
+    valueChanges.pipe(takeUntil(this._ngUnsubscribe$)).subscribe(value => this._pushSelectedValuesToDataSource(value));
   }
 
   public ngOnDestroy() {


### PR DESCRIPTION
values set before AfterViewInit of ps-select-data didn't trigger selectedValuesChanged of the
datasource