### PR TITLE
perf(table): less layout trashing on data update

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -140,5 +140,8 @@
       }
     }
   },
-  "defaultProject": "prosoft-components-demo"
+  "defaultProject": "prosoft-components-demo",
+  "cli": {
+    "analytics": false
+  }
 }

--- a/projects/components/table/src/subcomponents/table-data.component.html
+++ b/projects/components/table/src/subcomponents/table-data.component.html
@@ -1,4 +1,4 @@
-<table mat-table multiTemplateDataRows class="ps-table-data__table" [dataSource]="dataSource">
+<table mat-table multiTemplateDataRows class="ps-table-data__table" [dataSource]="dataSource" [trackBy]="dataSource.trackBy">
   <!-- Checkbox Column -->
   <ng-container matColumnDef="select">
     <th mat-header-cell *matHeaderCellDef>

--- a/projects/prosoft-components-demo/src/app/slider-demo/slider-demo.component.ts
+++ b/projects/prosoft-components-demo/src/app/slider-demo/slider-demo.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy } from '@angular/compiler/src/core';
+import { ChangeDetectionStrategy } from '@angular/core';
 import { ChangeDetectorRef, Component } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 

--- a/projects/prosoft-components-demo/src/app/table-demo/table-demo.component.ts
+++ b/projects/prosoft-components-demo/src/app/table-demo/table-demo.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy } from '@angular/compiler/src/core';
+import { ChangeDetectionStrategy } from '@angular/core';
 import { ChangeDetectorRef, Component, ViewChild } from '@angular/core';
 import { PageEvent } from '@angular/material/paginator';
 import { MatSelectChange } from '@angular/material/select';


### PR DESCRIPTION
With mode 'client' the rendered rows won't be trashed and rerendered anymore if the data is already
cached and can be synchronously filtered/sorted/paged. Also a trackBy function can now be set in the
dataSource.