### PR TITLE
refactor(table): table settings cleanup

### DIFF
--- a/docs/table.md
+++ b/docs/table.md
@@ -113,10 +113,10 @@ const dataSource = new PsTableDataSource<MyDataType>((filter: IPsTableUpdateData
 
 1. You have to override `PsTableSettingsService` and implement the following functions:
 
-- > `constructor` to define the loading of the settings for each table.
-- > `save(tableId: string, settings: IPsTableSetting): Observable<void>` to tell the table service where to store the settings for each table.
+- > `getStream(tableId: string, onlySaved: boolean): Observable<IPsTableSetting>` to get the settings for the table with the given id. If `onlySaved` is `true`, then only the saved settings should be returned. Otherwise the result can be a combination of saved an default settings.
+- > `save(tableId: string, settings: IPsTableSetting): Observable<void>` to save the settings for then table with the given id.
 
-2. Import the PsFormBaseModule using `.forRoot()` with the created service in your AppModule. Like this:
+1. Import the PsFormBaseModule using `.forRoot()` with the created service in your AppModule. Like this:
    `PsFormBaseModule.forRoot(DemoPsFormsService)`
 
 ---

--- a/projects/components/table/src/services/table-settings.service.ts
+++ b/projects/components/table/src/services/table-settings.service.ts
@@ -10,11 +10,16 @@ export interface IPsTableSetting {
 
 @Injectable({ providedIn: 'root' })
 export class PsTableSettingsService {
-  public defaultPageSize$: Observable<number> = of(15);
-  public settings$: Observable<{ [id: string]: IPsTableSetting }> = of({});
-
   public settingsEnabled = false;
   public pageSizeOptions = [5, 10, 25, 50];
+  public getStream(tableId: string, onlySaved: boolean): Observable<IPsTableSetting> {
+    return of({
+      columnBlacklist: [],
+      sortColumn: null,
+      sortDirection: null,
+      pageSize: 15,
+    });
+  }
 
   public save(_: string, __: IPsTableSetting): Observable<void> {
     return EMPTY;

--- a/projects/components/table/src/subcomponents/table-settings.component.spec.ts
+++ b/projects/components/table/src/subcomponents/table-settings.component.spec.ts
@@ -78,7 +78,7 @@ describe('PsTableSettingsComponent', () => {
       expect(component.onSettingsAborted).toHaveBeenCalled();
     }));
 
-    it('should emit call service save and emit settingsSaved on save click', fakeAsync(() => {
+    it('should call service save and emit settingsSaved on save click', fakeAsync(() => {
       const fixture = TestBed.createComponent(TestComponent);
       const component = fixture.componentInstance;
 
@@ -89,9 +89,7 @@ describe('PsTableSettingsComponent', () => {
         sortDirection: 'desc',
       };
       component.tableId = 'tableA';
-      component.tableSearch.settingsService.settings$ = of({
-        tableA: settings,
-      });
+      component.tableSearch.settingsService.getStream = () => of(settings);
       fixture.detectChanges();
 
       spyOn(component, 'onSettingsSaved');
@@ -120,9 +118,7 @@ describe('PsTableSettingsComponent', () => {
       const settingsService = new PsTableSettingsService();
       const component = new PsTableSettingsComponent(settingsService);
       component.tableId = 'table.1';
-      settingsService.settings$ = of({
-        'table.1': tableSetting,
-      });
+      spyOn(settingsService, 'getStream').and.returnValue(of(tableSetting));
       component.ngOnInit();
 
       let asyncSettings: IPsTableSetting;
@@ -131,13 +127,13 @@ describe('PsTableSettingsComponent', () => {
       });
 
       expect(asyncSettings).toEqual(tableSetting);
+      expect(settingsService.getStream).toHaveBeenCalledWith('table.1', true);
     }));
 
     it("should use default settings if service doesn't return settings", fakeAsync(() => {
       const settingsService = new PsTableSettingsService();
       const component = new PsTableSettingsComponent(settingsService);
       component.tableId = 'table.1';
-      settingsService.defaultPageSize$ = of(9);
       component.ngOnInit();
 
       let asyncSettings: IPsTableSetting;
@@ -147,7 +143,7 @@ describe('PsTableSettingsComponent', () => {
 
       expect(asyncSettings).toEqual({
         columnBlacklist: [],
-        pageSize: 9,
+        pageSize: 15,
         sortColumn: null,
         sortDirection: 'asc',
       });

--- a/projects/components/table/src/subcomponents/table-settings.component.ts
+++ b/projects/components/table/src/subcomponents/table-settings.component.ts
@@ -1,8 +1,9 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output, TemplateRef } from '@angular/core';
 import { MatCheckboxChange } from '@angular/material/checkbox';
 import { IPsTableIntlTexts } from '@prosoft/components/core';
-import { combineLatest, Observable, Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
+
 import { PsTableColumnDirective } from '../directives/table.directives';
 import { IPsTableSortDefinition } from '../models';
 import { IPsTableSetting, PsTableSettingsService } from '../services/table-settings.service';
@@ -45,17 +46,14 @@ export class PsTableSettingsComponent implements OnInit {
   constructor(public settingsService: PsTableSettingsService) {}
 
   public ngOnInit(): void {
-    this.settings$ = combineLatest([this.settingsService.settings$, this.settingsService.defaultPageSize$]).pipe(
-      map(([allSettings, defaultPageSize]) => {
-        if (allSettings[this.tableId]) {
-          return allSettings[this.tableId];
-        }
-
+    this.settings$ = this.settingsService.getStream(this.tableId, true).pipe(
+      map(settings => {
+        settings = settings || ({} as IPsTableSetting);
         return <IPsTableSetting>{
-          columnBlacklist: [],
-          pageSize: defaultPageSize || 15,
-          sortColumn: null,
-          sortDirection: 'asc',
+          columnBlacklist: settings.columnBlacklist || [],
+          pageSize: settings.pageSize || 15,
+          sortColumn: settings.sortColumn,
+          sortDirection: settings.sortDirection || 'asc',
         };
       })
     );

--- a/projects/prosoft-components-demo/src/app/table-demo/table-demo.module.ts
+++ b/projects/prosoft-components-demo/src/app/table-demo/table-demo.module.ts
@@ -9,17 +9,23 @@ import { MatSelectModule } from '@angular/material/select';
 import { RouterModule } from '@angular/router';
 import { PsIntlService, PsIntlServiceEn } from '@prosoft/components/core';
 import { IPsTableSetting, PsTableModule, PsTableSettingsService } from '@prosoft/components/table';
-import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
+import { BehaviorSubject, Observable, of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
 import { TableDemoComponent } from './table-demo.component';
 
 export class DemoPsTableSettingsService extends PsTableSettingsService {
+  private settings$ = new BehaviorSubject<{ [id: string]: IPsTableSetting }>({});
   constructor() {
     super();
     this.settingsEnabled = true;
-    this.settings$ = new BehaviorSubject<{ [id: string]: IPsTableSetting }>({});
+  }
+
+  public getStream(tableId: string): Observable<IPsTableSetting> {
+    return this.settings$.pipe(map(settings => settings[tableId]));
   }
   public save(tableId: string, settings: IPsTableSetting): Observable<void> {
-    (this.settings$ as Subject<{ [id: string]: IPsTableSetting }>).next({ [tableId]: settings });
+    this.settings$.next({ [tableId]: settings });
     return of(null);
   }
 }


### PR DESCRIPTION
The table now doesn't have to subscribe to settings and defaultPageSize separatelly

BREAKING CHANGE: The PsTableSettingsService now has a getStream method instead of the settings$ and defaultPageSize$ observables