### PR TITLE
refactor(savebar): remove prev/next button support

### DIFF
--- a/docs/savebar.md
+++ b/docs/savebar.md
@@ -34,8 +34,6 @@ import { PsSavebarModule } from '@prosoft/components/savebar';
 | `form: FormGroup`                               | Angular's `FormGroup`                                                                           |
 | `mode: 'sticky' \| 'fixed' \| 'auto' \| 'hide'` | Sets the mode of the savebar.                                                                   |
 | `canSave: boolean \| null`                      | If set, the savebar checks this value instead of the `FormGroups` state.                        |
-| `canStepFwd: boolean`                           | (In wizard) Checks, if you can step to the next part of the wizard.                             |
-| `canStepBack: boolean`                          | (In wizard) Checks, if you can step to the previous part of the wizard.                         |
 | `intlOverride: Partial<IPsSavebarIntlTexts>`    | If you want to override displayed labels.                                                       |
 | `saveKey: string`                               | The keyboard key to use as a save shortcut in combination with 'ctrl' (default 's' => ctrl + s) |
 
@@ -45,7 +43,6 @@ import { PsSavebarModule } from '@prosoft/components/savebar';
 | ---------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `save: EventEmitter<void>`         | If you handle this, a 'Save' button is shown.                                                       |
 | `saveAndClose: EventEmitter<void>` | If you handle this, a 'Save & close' button is shown.                                               |
-| `step: EventEmitter<number>`       | If you handle this, 'Next' and 'Previous' buttons are shown. The `number` is the next steps number. |
 | `cancel: EventEmitter<void>`       | If you handle this, a 'Cancel' button is shown.                                                     |
 
 ### Types <a name="PsSavebarComponentTypes"></a>
@@ -90,12 +87,9 @@ Now you can use it in your components like this:
 ```html
 <ps-savebar
   [form]="form"
-  [canStepFwd]="true"
-  [canStepBack]="true"
   (save)="onButtonClick('save')"
   (saveAndClose)="onButtonClick('saveAndClose')"
   (cancel)="onButtonClick('cancel')"
-  (step)="onButtonClick($event < 0 ? 'prev' : 'next')"
 >
   <mat-card>
     <form [formGroup]="form">

--- a/projects/components/core/src/intl.ts
+++ b/projects/components/core/src/intl.ts
@@ -6,8 +6,6 @@ export interface IPsSavebarIntlTexts {
   saveLabel: string;
   saveAndCloseLabel: string;
   cancelLabel: string;
-  nextLabel: string;
-  prevLabel: string;
 }
 
 // tslint:disable-next-line: no-empty-interface
@@ -60,8 +58,6 @@ export class PsIntlServiceEn extends PsIntlService {
     saveLabel: 'Save',
     saveAndCloseLabel: 'Save & close',
     cancelLabel: 'Cancel',
-    nextLabel: 'Next',
-    prevLabel: 'Previous',
   };
 
   private tableIntl: IPsTableIntlTexts = {

--- a/projects/components/savebar/src/savebar.component.html
+++ b/projects/components/savebar/src/savebar.component.html
@@ -31,28 +31,6 @@
 
       <ng-container *ngIf="customRightContent" [ngTemplateOutlet]="customRightContent"></ng-container>
 
-      <button
-        *ngIf="hasObservers(step)"
-        mat-stroked-button
-        type="button"
-        class="ps-savebar__button__prev"
-        (click)="step.emit(-1)"
-        [disabled]="!canStepBack"
-      >
-        {{ intl?.prevLabel }}
-      </button>
-      <button
-        *ngIf="hasObservers(step)"
-        mat-raised-button
-        type="button"
-        color="primary"
-        class="ps-savebar__button__next"
-        (click)="step.emit(1)"
-        [disabled]="!canStepFwd"
-      >
-        {{ intl?.nextLabel }}
-      </button>
-
       <button *ngIf="hasObservers(cancel)" mat-stroked-button type="button" class="ps-savebar__button__cancel" (click)="cancel.emit()">
         {{ intl?.cancelLabel }}
       </button>

--- a/projects/components/savebar/src/savebar.component.spec.ts
+++ b/projects/components/savebar/src/savebar.component.spec.ts
@@ -35,15 +35,7 @@ class TestPsFormService extends BasePsFormService {
 @Component({
   selector: 'ps-test-component',
   template: `
-    <ps-savebar
-      [form]="form"
-      [mode]="mode"
-      [canSave]="canSave"
-      [canStepFwd]="canStepFwd"
-      [canStepBack]="canStepBack"
-      [intlOverride]="intlOverride"
-      [saveKey]="saveKey"
-    >
+    <ps-savebar [form]="form" [mode]="mode" [canSave]="canSave" [intlOverride]="intlOverride" [saveKey]="saveKey">
       <div [formGroup]="form">
         <input type="text" [formControlName]="'input'" />
       </div>
@@ -60,8 +52,6 @@ export class TestComponent {
   });
   public mode: 'sticky' | 'fixed' | 'auto' | 'hide' = null;
   public canSave: boolean | null = null;
-  public canStepFwd: boolean;
-  public canStepBack: boolean;
   public intlOverride: Partial<IPsSavebarIntlTexts>;
   public saveKey: string = null;
 
@@ -308,76 +298,6 @@ describe('PsSavebarComponent', () => {
     outputSubscription.unsubscribe();
   }));
 
-  it('prev button should work', async(() => {
-    const fixture = TestBed.createComponent(TestComponent);
-    const component = fixture.componentInstance;
-    expect(component).toBeDefined();
-    fixture.detectChanges();
-
-    // button not visible without subscription
-    expect(fixture.debugElement.query(By.css('.ps-savebar__button__prev'))).toBe(null);
-
-    // subscription to output should activate the button
-    let outputValue = null;
-    const outputSubscription = component.savebar.step.subscribe((x: number) => {
-      outputValue = x;
-    });
-    component.mode = 'fixed'; // change some input to trigger change detection
-    fixture.detectChanges();
-
-    const buttonEl = fixture.debugElement.query(By.css('.ps-savebar__button__prev')).nativeElement;
-    expect(buttonEl).toBeDefined();
-
-    component.canStepBack = true;
-    fixture.detectChanges();
-    expect(buttonEl.disabled).toBe(false);
-
-    component.canStepBack = false;
-    fixture.detectChanges();
-    expect(buttonEl.disabled).toBe(true);
-
-    expect(outputValue).toBe(null);
-    buttonEl.dispatchEvent(new Event('click'));
-    expect(outputValue).toBe(-1);
-
-    outputSubscription.unsubscribe();
-  }));
-
-  it('next button should work', async(() => {
-    const fixture = TestBed.createComponent(TestComponent);
-    const component = fixture.componentInstance;
-    expect(component).toBeDefined();
-    fixture.detectChanges();
-
-    // button not visible without subscription
-    expect(fixture.debugElement.query(By.css('.ps-savebar__button__next'))).toBe(null);
-
-    // subscription to output should activate the button
-    let outputValue = null;
-    const outputSubscription = component.savebar.step.subscribe((x: number) => {
-      outputValue = x;
-    });
-    component.mode = 'fixed'; // change some input to trigger change detection
-    fixture.detectChanges();
-
-    const buttonEl = fixture.debugElement.query(By.css('.ps-savebar__button__next')).nativeElement;
-    expect(buttonEl).toBeDefined();
-
-    component.canStepFwd = true;
-    fixture.detectChanges();
-    expect(buttonEl.disabled).toBe(false);
-
-    component.canStepFwd = false;
-    fixture.detectChanges();
-    expect(buttonEl.disabled).toBe(true);
-
-    expect(outputValue).toBe(null);
-    buttonEl.dispatchEvent(new Event('click'));
-    expect(outputValue).toBe(1);
-
-    outputSubscription.unsubscribe();
-  }));
-
   it('should show psSavebarRightContent', async(() => {
     const fixture = TestBed.createComponent(TestComponent);
     const component = fixture.componentInstance;
@@ -399,8 +319,6 @@ describe('PsSavebarComponent', () => {
       saveLabel: 'Save',
       saveAndCloseLabel: 'Save & close',
       cancelLabel: 'Cancel',
-      prevLabel: 'Previous',
-      nextLabel: 'Next',
     });
 
     // Full override
@@ -408,8 +326,6 @@ describe('PsSavebarComponent', () => {
       saveLabel: 's',
       saveAndCloseLabel: 'sac',
       cancelLabel: 'c',
-      prevLabel: 'p',
-      nextLabel: 'n',
     };
     fixture.detectChanges();
 
@@ -417,8 +333,6 @@ describe('PsSavebarComponent', () => {
       saveLabel: 's',
       saveAndCloseLabel: 'sac',
       cancelLabel: 'c',
-      prevLabel: 'p',
-      nextLabel: 'n',
     });
 
     // Partial override
@@ -432,8 +346,6 @@ describe('PsSavebarComponent', () => {
       saveLabel: 's',
       saveAndCloseLabel: 'sac',
       cancelLabel: 'Cancel',
-      prevLabel: 'Previous',
-      nextLabel: 'Next',
     });
   }));
 

--- a/projects/components/savebar/src/savebar.component.ts
+++ b/projects/components/savebar/src/savebar.component.ts
@@ -33,14 +33,11 @@ export class PsSavebarComponent implements OnInit, OnChanges, OnDestroy {
   @Input() public mode: IPsSavebarMode = 'auto';
   @Input() public form: FormGroup;
   @Input() public canSave: boolean | null;
-  @Input() public canStepFwd: boolean;
-  @Input() public canStepBack: boolean;
   @Input() public intlOverride: Partial<IPsSavebarIntlTexts>;
   @Input() public saveKey = 's';
 
   @Output() public save = new EventEmitter<void>();
   @Output() public saveAndClose = new EventEmitter<void>();
-  @Output() public step = new EventEmitter<number>();
   @Output() public cancel = new EventEmitter<void>();
 
   @ContentChild(PsSavebarRightContentDirective, { read: TemplateRef, static: false })

--- a/projects/prosoft-components-demo/src/app/savebar-demo/savebar-demo.component.ts
+++ b/projects/prosoft-components-demo/src/app/savebar-demo/savebar-demo.component.ts
@@ -6,12 +6,9 @@ import { FormControl, FormGroup, Validators, AbstractControl } from '@angular/fo
   template: `
     <ps-savebar
       [form]="form"
-      [canStepFwd]="true"
-      [canStepBack]="true"
       (save)="onButtonClick('save')"
       (saveAndClose)="onButtonClick('saveAndClose')"
       (cancel)="onButtonClick('cancel')"
-      (step)="onButtonClick($event < 0 ? 'prev' : 'next')"
     >
       <mat-card>
         <form [formGroup]="form">


### PR DESCRIPTION
This feature is unused and doesn't really fit to the scope of the savebar. This should be done with
psSavebarRightContent.

BREAKING CHANGE: removed prev/next button support