### PR TITLE
feat(table): pass loadTrigger data to loadFn

### DIFF
--- a/projects/components/table/public_api.ts
+++ b/projects/components/table/public_api.ts
@@ -1,5 +1,5 @@
 export { IPsTableFilterResult, PsTableDataSource } from './src/data/table-data-source';
-export { IPsTableSortDefinition, IPsTableUpdateDataInfo } from './src/models';
+export { IPsTableSortDefinition, IPsTableUpdateDataInfo, IExtendedPsTableUpdateDataInfo } from './src/models';
 export { IPsTableSetting, PsTableSettingsService } from './src/services/table-settings.service';
 export { PsTableComponent } from './src/table.component';
 export { PsTableModule } from './src/table.module';

--- a/projects/components/table/src/data/table-data-source.spec.ts
+++ b/projects/components/table/src/data/table-data-source.spec.ts
@@ -477,7 +477,14 @@ describe('PsTableDataSource', () => {
 
   describe('getUpdateDataInfo', () => {
     it('should work', () => {
-      const dataSource = new PsTableDataSource<any>(() => of([]), 'client');
+      const loadTrigger$ = new Subject<string>();
+      const dataSource = new PsTableDataSource({
+        loadTrigger$: loadTrigger$,
+        loadDataFn: () => of([]),
+        mode: 'client',
+      });
+      dataSource.connect().subscribe();
+      loadTrigger$.next('triggered');
       dataSource.tableReady = true;
 
       dataSource.pageSize = 33;
@@ -507,6 +514,17 @@ describe('PsTableDataSource', () => {
         sortColumn: 'a',
         sortDirection: 'asc',
       });
+
+      expect(dataSource.getUpdateDataInfo(true)).toEqual({
+        pageSize: 5,
+        currentPage: 3,
+        searchText: null,
+        sortColumn: 'a',
+        sortDirection: 'asc',
+        triggerData: 'triggered',
+      });
+
+      dataSource.disconnect();
     });
   });
 

--- a/projects/components/table/src/data/table-data-source.spec.ts
+++ b/projects/components/table/src/data/table-data-source.spec.ts
@@ -224,7 +224,7 @@ describe('PsTableDataSource', () => {
   it('should not sort/filter/page, but provide info to loadData when mode is server', () => {
     const loadedData = Array.from(new Array(20).keys()).map(x => ({ prop: x }));
     let lastUpdateInfo: IPsTableUpdateDataInfo = null;
-    const dataSource = new PsTableDataSource<any>(updateInfo => {
+    const dataSource = new PsTableDataSource<any>((triggerData, updateInfo) => {
       lastUpdateInfo = updateInfo;
       return of(loadedData);
     }, 'server');
@@ -577,7 +577,7 @@ describe('PsTableDataSource', () => {
   });
 
   it('should update visibleRows, data and dataLength on server pagination', () => {
-    const dataSource = new PsTableDataSource<any>(filter => {
+    const dataSource = new PsTableDataSource<any>((triggerData, filter) => {
       return of({ Items: [{ prop: filter.currentPage }], TotalItems: 100 });
     }, 'server');
     dataSource.tableReady = true;
@@ -608,7 +608,7 @@ describe('PsTableDataSource', () => {
   });
 
   it('should fix pageIndex when currentPage would have no items on server pagination', () => {
-    const dataSource = new PsTableDataSource<any>(filter => {
+    const dataSource = new PsTableDataSource<any>((triggerData, filter) => {
       return of({ Items: [{ prop: filter.currentPage }], TotalItems: 1 });
     }, 'server');
     dataSource.tableReady = true;

--- a/projects/components/table/src/data/table-data-source.ts
+++ b/projects/components/table/src/data/table-data-source.ts
@@ -12,9 +12,9 @@ import { IPsTableUpdateDataInfo } from '../models';
  */
 const MAX_SAFE_INTEGER = 9007199254740991;
 
-export interface PsTableDataSourceOptions<TData> {
-  loadTrigger$?: Observable<any>;
-  loadDataFn: (filter: IPsTableUpdateDataInfo) => Observable<TData[] | IPsTableFilterResult<TData>>;
+export interface PsTableDataSourceOptions<TData, TTrigger = any> {
+  loadTrigger$?: Observable<TTrigger>;
+  loadDataFn: (triggerData: TTrigger, filter: IPsTableUpdateDataInfo) => Observable<TData[] | IPsTableFilterResult<TData>>;
   mode?: PsTableMode;
 }
 
@@ -25,7 +25,7 @@ export interface IPsTableFilterResult<T> {
 
 declare type PsTableMode = 'client' | 'server';
 
-export class PsTableDataSource<T> extends DataSource<T> {
+export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
   /** Subject that emits, when the table should be checked by the change detection */
   public _internalDetectChanges = new Subject<void>();
 
@@ -88,7 +88,7 @@ export class PsTableDataSource<T> extends DataSource<T> {
   /** Stream that emits when a new data array is set on the data source. */
   private readonly _updateDataTrigger$: Observable<any>;
 
-  private readonly _loadData: (filter: IPsTableUpdateDataInfo) => Observable<T[] | IPsTableFilterResult<T>>;
+  private readonly _loadData: (triggerData: TTrigger, filter: IPsTableUpdateDataInfo) => Observable<T[] | IPsTableFilterResult<T>>;
 
   /** Stream that emits when a new data array is set on the data source. */
   private readonly _data: BehaviorSubject<T[]> = new BehaviorSubject<T[]>([]);
@@ -98,6 +98,8 @@ export class PsTableDataSource<T> extends DataSource<T> {
 
   /** Indicates if the data source currently holds data provided by the _loadData function. */
   private _hasData = false;
+
+  private _lastLoadTriggerData: TTrigger = null;
 
   /**
    * Subscription to the result of the loadData function.
@@ -114,14 +116,19 @@ export class PsTableDataSource<T> extends DataSource<T> {
    */
   private _renderChangesSubscription = Subscription.EMPTY;
 
-  constructor(options: PsTableDataSourceOptions<T>);
-  constructor(loadDataFn: (filter: IPsTableUpdateDataInfo) => Observable<T[] | IPsTableFilterResult<T>>, mode?: PsTableMode);
+  constructor(options: PsTableDataSourceOptions<T, TTrigger>);
   constructor(
-    optionsOrLoadDataFn: PsTableDataSourceOptions<T> | ((filter: IPsTableUpdateDataInfo) => Observable<T[] | IPsTableFilterResult<T>>),
+    loadDataFn: (triggerData: TTrigger, filter: IPsTableUpdateDataInfo) => Observable<T[] | IPsTableFilterResult<T>>,
+    mode?: PsTableMode
+  );
+  constructor(
+    optionsOrLoadDataFn:
+      | PsTableDataSourceOptions<T, TTrigger>
+      | ((triggerData: TTrigger, filter: IPsTableUpdateDataInfo) => Observable<T[] | IPsTableFilterResult<T>>),
     mode?: PsTableMode
   ) {
     super();
-    const options: PsTableDataSourceOptions<T> =
+    const options: PsTableDataSourceOptions<T, TTrigger> =
       'loadDataFn' in optionsOrLoadDataFn ? optionsOrLoadDataFn : { loadDataFn: optionsOrLoadDataFn, mode: mode };
 
     this.mode = options.mode || 'client';
@@ -289,7 +296,7 @@ export class PsTableDataSource<T> extends DataSource<T> {
       this._internalDetectChanges.next();
 
       const filter = this.getUpdateDataInfo();
-      this._loadDataSubscription = this._loadData(filter)
+      this._loadDataSubscription = this._loadData(this._lastLoadTriggerData, filter)
         .pipe(
           take(1),
           tap(() => (this._hasData = true)),
@@ -340,7 +347,10 @@ export class PsTableDataSource<T> extends DataSource<T> {
    * @docs-private
    */
   public connect() {
-    this._updateDataTriggerSub = this._updateDataTrigger$.subscribe(() => this.updateData());
+    this._updateDataTriggerSub = this._updateDataTrigger$.subscribe(data => {
+      this._lastLoadTriggerData = data;
+      this.updateData();
+    });
     return this._renderData;
   }
 

--- a/projects/components/table/src/data/table-data-source.ts
+++ b/projects/components/table/src/data/table-data-source.ts
@@ -14,7 +14,7 @@ const MAX_SAFE_INTEGER = 9007199254740991;
 
 export interface PsTableDataSourceOptions<TData, TTrigger = any> {
   loadTrigger$?: Observable<TTrigger>;
-  loadDataFn: (filter: IExtendedPsTableUpdateDataInfo<TTrigger>) => Observable<TData[] | IPsTableFilterResult<TData>>;
+  loadDataFn: (updateInfo: IExtendedPsTableUpdateDataInfo<TTrigger>) => Observable<TData[] | IPsTableFilterResult<TData>>;
   mode?: PsTableMode;
 }
 
@@ -88,7 +88,7 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
   /** Stream that emits when a new data array is set on the data source. */
   private readonly _updateDataTrigger$: Observable<any>;
 
-  private readonly _loadData: (filter: IExtendedPsTableUpdateDataInfo<TTrigger>) => Observable<T[] | IPsTableFilterResult<T>>;
+  private readonly _loadData: (updateInfo: IExtendedPsTableUpdateDataInfo<TTrigger>) => Observable<T[] | IPsTableFilterResult<T>>;
 
   /** Stream that emits when a new data array is set on the data source. */
   private readonly _data: BehaviorSubject<T[]> = new BehaviorSubject<T[]>([]);
@@ -118,13 +118,13 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
 
   constructor(options: PsTableDataSourceOptions<T, TTrigger>);
   constructor(
-    loadDataFn: (filter: IExtendedPsTableUpdateDataInfo<TTrigger>) => Observable<T[] | IPsTableFilterResult<T>>,
+    loadDataFn: (updateInfo: IExtendedPsTableUpdateDataInfo<TTrigger>) => Observable<T[] | IPsTableFilterResult<T>>,
     mode?: PsTableMode
   );
   constructor(
     optionsOrLoadDataFn:
       | PsTableDataSourceOptions<T, TTrigger>
-      | ((filter: IExtendedPsTableUpdateDataInfo<TTrigger>) => Observable<T[] | IPsTableFilterResult<T>>),
+      | ((updateInfo: IExtendedPsTableUpdateDataInfo<TTrigger>) => Observable<T[] | IPsTableFilterResult<T>>),
     mode?: PsTableMode
   ) {
     super();
@@ -301,8 +301,8 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
       this._renderData.next([]);
       this._internalDetectChanges.next();
 
-      const filter = this.getUpdateDataInfo(true);
-      this._loadDataSubscription = this._loadData(filter)
+      const updateInfo = this.getUpdateDataInfo(true);
+      this._loadDataSubscription = this._loadData(updateInfo)
         .pipe(
           take(1),
           tap(() => (this._hasData = true)),

--- a/projects/components/table/src/models.ts
+++ b/projects/components/table/src/models.ts
@@ -10,3 +10,7 @@ export interface IPsTableUpdateDataInfo {
   sortDirection: 'asc' | 'desc' | null;
   sortColumn: string | null;
 }
+
+export interface IExtendedPsTableUpdateDataInfo<TTrigger> extends IPsTableUpdateDataInfo {
+  triggerData: TTrigger;
+}

--- a/projects/components/table/src/table.component.spec.ts
+++ b/projects/components/table/src/table.component.spec.ts
@@ -370,7 +370,7 @@ describe('PsTableComponent', () => {
       expect(router.navigate).toHaveBeenCalledWith([], { queryParams: expectedQueryParams, relativeTo: route });
     });
 
-    it('should set locale and update data if data source changes', fakeAsync(() => {
+    it('should set locale on the data source', fakeAsync(() => {
       const initialDataSource = new PsTableDataSource(() => of([]), 'client');
       spyOn(initialDataSource, 'updateData');
       const newDataSource = new PsTableDataSource(() => of([]), 'client');
@@ -378,21 +378,12 @@ describe('PsTableComponent', () => {
 
       const table = createTableInstance();
       table.dataSource = initialDataSource;
-      table.ngOnChanges({ dataSource: new SimpleChange(null, initialDataSource, true) });
       table.ngOnInit();
       table.ngAfterContentInit();
 
       tick(1);
 
       expect(initialDataSource.locale).toBe('de');
-
-      table.dataSource = newDataSource;
-      table.ngOnChanges({ dataSource: new SimpleChange(null, newDataSource, false) });
-
-      expect(newDataSource.locale).toBe('de');
-
-      expect(initialDataSource.updateData).toHaveBeenCalledTimes(1);
-      expect(newDataSource.updateData).toHaveBeenCalledTimes(1);
     }));
 
     it('should update state when sort changes', fakeAsync(() => {

--- a/projects/components/table/src/table.component.ts
+++ b/projects/components/table/src/table.component.ts
@@ -203,19 +203,13 @@ export class PsTableComponent implements OnInit, OnChanges, AfterContentInit, On
       this.cd.markForCheck();
     });
 
+    this.dataSource.locale = this._locale;
     this.pageSizeOptions = this.settingsService.pageSizeOptions;
   }
 
   public ngOnChanges(changes: SimpleChanges) {
     if (changes.intlOverride) {
       this.updateIntl();
-    }
-
-    if (changes.dataSource) {
-      this.dataSource.locale = this._locale;
-      if (!changes.dataSource.firstChange) {
-        this.dataSource.updateData();
-      }
     }
   }
 


### PR DESCRIPTION
Things to be aware of:
- loadTrigger$ emits before the ps-table called connect() are ignored
- the triggerData passed to loadFn can still be null if loadTrigger$ didn't emit.
- can't pass new trigger data to a manual updateData() call. Should this be allowed?

fixes #88 