### PR TITLE
refactor(table): fixed casing of IPsTableFilterResult properties

### DIFF
--- a/projects/components/table/src/data/table-data-source.spec.ts
+++ b/projects/components/table/src/data/table-data-source.spec.ts
@@ -597,7 +597,7 @@ describe('PsTableDataSource', () => {
 
   it('should update visibleRows, data and dataLength on server pagination', () => {
     const dataSource = new PsTableDataSource<any>(filter => {
-      return of({ Items: [{ prop: filter.currentPage }], TotalItems: 100 });
+      return of({ items: [{ prop: filter.currentPage }], totalItems: 100 });
     }, 'server');
     dataSource.tableReady = true;
     dataSource.pageIndex = 0;
@@ -628,7 +628,7 @@ describe('PsTableDataSource', () => {
 
   it('should fix pageIndex when currentPage would have no items on server pagination', () => {
     const dataSource = new PsTableDataSource<any>(filter => {
-      return of({ Items: [{ prop: filter.currentPage }], TotalItems: 1 });
+      return of({ items: [{ prop: filter.currentPage }], totalItems: 1 });
     }, 'server');
     dataSource.tableReady = true;
     dataSource.pageIndex = 1;

--- a/projects/components/table/src/data/table-data-source.ts
+++ b/projects/components/table/src/data/table-data-source.ts
@@ -19,8 +19,8 @@ export interface PsTableDataSourceOptions<TData, TTrigger = any> {
 }
 
 export interface IPsTableFilterResult<T> {
-  Items: T[];
-  TotalItems: number;
+  items: T[];
+  totalItems: number;
 }
 
 declare type PsTableMode = 'client' | 'server';
@@ -323,9 +323,9 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
           } else {
             const filterResult = data;
 
-            this.dataLength = filterResult.TotalItems;
-            this.data = filterResult.Items;
-            this._checkPageValidity(filterResult.TotalItems);
+            this.dataLength = filterResult.totalItems;
+            this.data = filterResult.items;
+            this._checkPageValidity(filterResult.totalItems);
           }
         });
     } else {


### PR DESCRIPTION
The properties of IPsTableFilterResult were pascal case instead of camel case like the rest of the
code.

BREAKING CHANGE: IPsTableFilterResult properties are now camel case

fix #89