### PR TITLE
fix: style fixes for table and form

### DIFF
--- a/projects/components/form/src/form.component.scss
+++ b/projects/components/form/src/form.component.scss
@@ -7,16 +7,16 @@
   grid-gap: 1em;
 }
 
-.ps-form__error-container {
+mat-card.ps-form__error-container {
   color: var(--ps-error);
 }
 
-.ps-form__error-container--center {
+mat-card.ps-form__error-container--center {
   display: grid;
   justify-items: center;
 }
 
-.ps-form__error-icon {
+mat-icon.ps-form__error-icon {
   color: var(--ps-error);
   font-size: 72px;
   height: 72px;

--- a/projects/components/table/src/table.component.scss
+++ b/projects/components/table/src/table.component.scss
@@ -23,3 +23,7 @@ ps-table {
     box-shadow: 0 -1px 6px -2px rgba(0, 0, 0, 0.2);
   }
 }
+
+.ps-table--card {
+  background-color: #fafafa;
+}

--- a/projects/components/table/src/table.component.spec.ts
+++ b/projects/components/table/src/table.component.spec.ts
@@ -495,6 +495,7 @@ describe('PsTableComponent', () => {
 
       // ps-table[cardLayout]
       expect(psTableDbg.classes['mat-elevation-z1']).toEqual(true);
+      expect(psTableDbg.classes['ps-table--card']).toEqual(true);
 
       // ps-table[striped]
       expect(psTableDbg.classes['ps-table--striped']).toEqual(true);

--- a/projects/components/table/src/table.component.ts
+++ b/projects/components/table/src/table.component.ts
@@ -76,6 +76,11 @@ export class PsTableComponent implements OnInit, OnChanges, AfterContentInit, On
   @HostBinding('class.mat-elevation-z1')
   public cardLayout = true;
 
+  @HostBinding('class.ps-table--card')
+  public get cardLayoutBinding() {
+    return this.cardLayout;
+  }
+
   @Input()
   @HostBinding('class.ps-table--striped')
   public striped = false;


### PR DESCRIPTION
table with card layout now has a background for the header. form css class selectivity increased to
prevent material styles from overriding the styles of the error card.