### PR TITLE
feat(select): items can be disabled

### DIFF
--- a/projects/components/select/src/defaults/default-select-data-source.spec.ts
+++ b/projects/components/select/src/defaults/default-select-data-source.spec.ts
@@ -644,14 +644,14 @@ interface Item {
   value: any;
 }
 
-function createItem(label: string, value: any): Item {
+export function createItem(label: string, value: any): Item {
   return {
     label: label,
     value: value,
   };
 }
 
-function createMissingOption(id: number, hidden = false): PsSelectItem {
+export function createMissingOption(id: number, hidden = false): PsSelectItem {
   return {
     label: `??? (ID: ${id})`,
     hidden: hidden,
@@ -659,21 +659,23 @@ function createMissingOption(id: number, hidden = false): PsSelectItem {
   };
 }
 
-function createIdOption(item: Item, hidden = false): PsSelectItem {
+export function createIdOption(item: Item, hidden = false, disabled = false): PsSelectItem {
   return {
     label: item.label,
     value: item.value,
     hidden: hidden,
     entity: item,
+    disabled: disabled,
   };
 }
 
-function createEntityOption(item: Item, hidden = false): PsSelectItem {
+export function createEntityOption(item: Item, hidden = false, disabled = false): PsSelectItem {
   return {
     label: item.label,
     value: item,
     hidden: hidden,
     entity: item,
+    disabled: disabled,
   };
 }
 

--- a/projects/components/select/src/defaults/default-select-data-source.ts
+++ b/projects/components/select/src/defaults/default-select-data-source.ts
@@ -22,6 +22,7 @@ export interface PsSelectDataSourceOptions<T = any> {
   mode: 'id' | 'entity';
   idKey: keyof T;
   labelKey: keyof T;
+  disabledKey?: keyof T;
   items: MaybeObservable<T[]> | (() => MaybeObservable<T[]>);
   searchDebounce?: number;
   loadTrigger?: PsSelectLoadTrigger;
@@ -70,7 +71,7 @@ export class DefaultPsSelectDataSource<T = any> extends PsSelectDataSource<T> {
     this._sortBy = options.sortBy == null ? PsSelectSortBy.Both : options.sortBy;
 
     let loadData: () => Observable<PsSelectItem<T>[]>;
-    const entityToSelectItem = createEntityToSelectItemMapper(options.mode, options.idKey, options.labelKey);
+    const entityToSelectItem = createEntityToSelectItemMapper(options.mode, options.idKey, options.labelKey, options.disabledKey);
 
     const items = options.items;
     if (typeof items !== 'function') {
@@ -278,18 +279,25 @@ export function ensureObservable<T>(data: T | Observable<T>): Observable<T> {
   return data;
 }
 
-function createEntityToSelectItemMapper(mode: 'id' | 'entity', idKey: keyof any, labelKey: keyof any): (item: any) => PsSelectItem<any> {
+function createEntityToSelectItemMapper(
+  mode: 'id' | 'entity',
+  idKey: keyof any,
+  labelKey: keyof any,
+  disabledKey: keyof any
+): (item: any) => PsSelectItem<any> {
   if (mode === 'id') {
     return (item: any) => ({
       value: item[idKey],
       label: item[labelKey],
       entity: item,
+      disabled: (disabledKey && item[disabledKey]) || false,
     });
   }
   return (item: any) => ({
     value: item,
     label: item[labelKey],
     entity: item,
+    disabled: (disabledKey && item[disabledKey]) || false,
   });
 }
 

--- a/projects/components/select/src/defaults/default-select-service.spec.ts
+++ b/projects/components/select/src/defaults/default-select-service.spec.ts
@@ -49,7 +49,7 @@ describe('DefaultPsSelectService', () => {
     expectEntityGetItemsForValues(dataSource, 'a', 'b');
 
     const renderOptions = getRenderData(dataSource);
-    expect(renderOptions).toEqual([{ value: item, label: 'item 1', hidden: false, entity: item }]);
+    expect(renderOptions).toEqual([createOption('item 1', item, item)]);
   }));
 
   it('should work with data object in id mode', fakeAsync(() => {
@@ -63,7 +63,7 @@ describe('DefaultPsSelectService', () => {
     expectIdGetItemsForValues(dataSource);
 
     const renderOptions = getRenderData(dataSource);
-    expect(renderOptions).toEqual([{ value: 1, label: 'item 1', hidden: false, entity: item }]);
+    expect(renderOptions).toEqual([createOption('item 1', 1, item)]);
   }));
 
   it('should work with data observable and custom options', fakeAsync(() => {
@@ -87,7 +87,7 @@ describe('DefaultPsSelectService', () => {
     expectEntityGetItemsForValues(dataSource, 'x', 'y');
 
     const renderOptions = getRenderData(dataSource);
-    expect(renderOptions).toEqual([{ value: item, label: 'item 1', hidden: false, entity: item }]);
+    expect(renderOptions).toEqual([createOption('item 1', item, item)]);
   }));
 
   it('should work with data array', fakeAsync(() => {
@@ -101,7 +101,7 @@ describe('DefaultPsSelectService', () => {
     expectIdGetItemsForValues(dataSource);
 
     const renderOptions = getRenderData(dataSource);
-    expect(renderOptions).toEqual([{ value: 1, label: 'item 1', hidden: false, entity: item }]);
+    expect(renderOptions).toEqual([createOption('item 1', 1, item)]);
   }));
 
   it('should work with observable array', fakeAsync(() => {
@@ -115,7 +115,17 @@ describe('DefaultPsSelectService', () => {
     expectIdGetItemsForValues(dataSource);
 
     const renderOptions = getRenderData(dataSource);
-    expect(renderOptions).toEqual([{ value: 1, label: 'item 1', hidden: false, entity: item }]);
+    expect(renderOptions).toEqual([createOption('item 1', 1, item)]);
+  }));
+
+  it('should set disabled to value of item[disabledKey]', fakeAsync(() => {
+    const service = new DefaultPsSelectService();
+
+    const item = { a: 1, b: 'item 1', d: true };
+    const dataSource = service.createDataSource({ mode: 'entity', idKey: 'a', labelKey: 'b', disabledKey: 'd', items: [item] }, null);
+
+    const renderOptions = getRenderData(dataSource);
+    expect(renderOptions).toEqual([createOption('item 1', item, item, false, true)]);
   }));
 });
 
@@ -167,4 +177,14 @@ function expectEntityGetItemsForValues(dataSource: PsSelectDataSource, idKey: st
 function expectDataSourceOptions(dataSource: any, loadTrigger: PsSelectLoadTrigger, debounceTime: number) {
   expect(dataSource._loadTrigger).toEqual(loadTrigger);
   expect(dataSource._searchDebounceTime).toEqual(debounceTime);
+}
+
+function createOption(label: string, value: any, entity: any, hidden = false, disabled = false): PsSelectItem {
+  return {
+    label: label,
+    value: value,
+    entity: entity,
+    hidden: hidden,
+    disabled: disabled,
+  };
 }

--- a/projects/components/select/src/models.ts
+++ b/projects/components/select/src/models.ts
@@ -3,4 +3,5 @@ export interface PsSelectItem<T = any> {
   value: T;
   entity?: any;
   hidden?: boolean;
+  disabled?: boolean;
 }

--- a/projects/components/select/src/select-data.component.ts
+++ b/projects/components/select/src/select-data.component.ts
@@ -39,6 +39,7 @@ import { PsSelectService } from './select.service';
       *ngFor="let item of items; trackBy: trackByOptions"
       [value]="item.value"
       [class.ps-option-hidden]="item.hidden"
+      [disabled]="item.disabled"
       class="ps-select-data__option"
     >
       <ng-container *ngIf="!optionTemplate">

--- a/projects/components/select/src/select.component.spec.ts
+++ b/projects/components/select/src/select.component.spec.ts
@@ -9,6 +9,8 @@ import { Subject, Subscription } from 'rxjs';
 import { PsSelectComponent } from './select.component';
 import { PsSelectModule } from './select.module';
 import { DefaultPsSelectService } from './defaults/default-select-service';
+import { PsSelectItem } from './models';
+import { DefaultPsSelectDataSource } from './defaults/default-select-data-source';
 
 function createMatSelect(): MatSelect {
   const matSelect = <any>{
@@ -114,7 +116,7 @@ export class TestComponent implements OnDestroy {
   `,
 })
 export class TestMultipleComponent {
-  dataSource = [{ value: 1, label: 'item1' }, { value: 2, label: 'item2' }];
+  dataSource: any = [{ value: 1, label: 'item1' }, { value: 2, label: 'item2' }];
   value: any = null;
 
   @ViewChild(PsSelectComponent, { static: true }) select: PsSelectComponent;
@@ -316,6 +318,29 @@ describe('PsSelectComponent', () => {
 
     // trigger text
     expect(matSelectTrigger.nativeElement.textContent.trim()).toEqual('trigger:blue:color:blue:Blue'); // static trigger text + value + mat-option viewValue
+  });
+  it('should disable matOption for item with disable', async () => {
+    const { fixture, component } = await initTest(TestMultipleComponent);
+    component.dataSource = new DefaultPsSelectDataSource({
+      mode: 'id',
+      labelKey: 'label',
+      idKey: 'value',
+      disabledKey: 'disabled',
+      items: [
+        { label: 'disabled', value: 1, disabled: true },
+        { label: 'active', value: 2, disabled: false },
+        { label: 'default', value: 3 },
+      ],
+    });
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const options = ((component.select as any)._matSelect as MatSelect).options.toArray();
+    expect(options.find(o => o.value === 1).disabled).toBeTruthy();
+    expect(options.find(o => o.value === 2).disabled).toBeFalsy();
+    expect(options.find(o => o.value === 3).disabled).toBeFalsy();
   });
 });
 

--- a/projects/prosoft-components-demo/src/app/select-demo/select-demo.component.ts
+++ b/projects/prosoft-components-demo/src/app/select-demo/select-demo.component.ts
@@ -172,6 +172,7 @@ export class SelectDemoComponent implements OnInit {
     strId: `id${i}`,
     labelA: `Label A ${i}`,
     labelB: `Label B ${i}`,
+    disabled: i % 5 === 4,
   }));
   public unknowIitem = {
     id: -1,
@@ -218,6 +219,7 @@ export class SelectDemoComponent implements OnInit {
       mode: this.dataSourceMode,
       idKey: this.dataSourceIdKey,
       labelKey: this.dataSourceLabelKey,
+      disabledKey: 'disabled',
       items: this.getDataSourceItems(logs),
       searchDebounce: this.dataSourceSearchDebounce,
       loadTrigger: this.getPsSelectLoadTrigger(),


### PR DESCRIPTION
items can be disabled by providing a 'disabledKey' to the DataSourceOptions and setting the property
of that name to true