### PR TITLE
fix(table): don't cancel data loading when only the view is updated

### DIFF
--- a/projects/components/table/src/data/table-data-source.ts
+++ b/projects/components/table/src/data/table-data-source.ts
@@ -161,7 +161,7 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
    * @returns The values to use in the filter.
    */
   public filterValues = (row: { [key: string]: any }): any[] => {
-    return this.filterProperties(row).map(key => row[key]);
+    return this.filterProperties(row).map((key) => row[key]);
   };
 
   /**
@@ -177,7 +177,7 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
   public filterPredicate = (row: { [key: string]: any }, filter: string) => {
     // Transform the data into a lowercase string of all property values.
     const dataStr = this.filterValues(row)
-      .map(value => (value instanceof Date ? value.toLocaleString(this.locale) : value + '').toLowerCase())
+      .map((value) => (value instanceof Date ? value.toLocaleString(this.locale) : value + '').toLowerCase())
       // Use an obscure Unicode character to delimit the words in the concatenated string.
       // This avoids matches where the values of two columns combined will match the user's query
       // (e.g. `Flute` and `Stop` will match `Test`). The character is intended to be something
@@ -291,12 +291,11 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
     if (!this.tableReady) {
       return;
     }
-    this._loadDataSubscription.unsubscribe();
-
-    this.error = null;
-    this.selectionModel.clear();
 
     if (this.mode === 'server' || forceReload || !this._hasData) {
+      this.selectionModel.clear();
+      this._loadDataSubscription.unsubscribe();
+      this.error = null;
       this.loading = true;
       this._renderData.next([]);
       this._internalDetectChanges.next();
@@ -316,7 +315,7 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
             this._internalDetectChanges.next();
           })
         )
-        .subscribe(data => {
+        .subscribe((data) => {
           if (Array.isArray(data)) {
             this.dataLength = data.length;
             this.data = data;
@@ -328,7 +327,8 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
             this._checkPageValidity(filterResult.totalItems);
           }
         });
-    } else {
+    } else if (!this.loading) {
+      this.selectionModel.clear();
       this._data.next(this.data);
       this._internalDetectChanges.next();
     }
@@ -353,7 +353,7 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
    * @docs-private
    */
   public connect() {
-    this._updateDataTriggerSub = this._updateDataTrigger$.subscribe(data => {
+    this._updateDataTriggerSub = this._updateDataTrigger$.subscribe((data) => {
       this._lastLoadTriggerData = data;
       this.updateData();
     });
@@ -378,13 +378,13 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
     let dataStream: Observable<T[]> = this._data;
     if (this.mode === 'client') {
       dataStream = dataStream.pipe(
-        map(data => this._filterData(data)),
-        map(data => this._orderData(data)),
-        map(data => this._pageData(data))
+        map((data) => this._filterData(data)),
+        map((data) => this._orderData(data)),
+        map((data) => this._pageData(data))
       );
     }
     this._renderChangesSubscription.unsubscribe();
-    this._renderChangesSubscription = dataStream.subscribe(data => this._renderData.next(data));
+    this._renderChangesSubscription = dataStream.subscribe((data) => this._renderData.next(data));
   }
 
   /**
@@ -396,7 +396,7 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
     // If there is a filter string, filter out data that does not contain it.
     // Each data object is converted to a string using the function defined by filterTermAccessor.
     // May be overridden for customization.
-    const filteredData = !this.filter ? data : data.filter(obj => this.filterPredicate(obj, this.filter));
+    const filteredData = !this.filter ? data : data.filter((obj) => this.filterPredicate(obj, this.filter));
 
     this.dataLength = filteredData.length;
 

--- a/projects/prosoft-components-demo/src/app/slider-demo/slider-demo.module.ts
+++ b/projects/prosoft-components-demo/src/app/slider-demo/slider-demo.module.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { NgModule, Injectable } from '@angular/core';
+import { Injectable, NgModule } from '@angular/core';
 import { FormControl, FormGroupDirective, FormsModule, NgForm, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -10,7 +10,9 @@ import { RouterModule } from '@angular/router';
 import { PsFormBaseModule } from '@prosoft/components/form-base';
 import { PsFormFieldModule } from '@prosoft/components/form-field';
 import { PsSliderModule } from '@prosoft/components/slider';
-import { Observable, of } from 'rxjs';
+
+import { DemoPsFormsService } from '../common/demo-ps-form-service';
+import { InvalidErrorStateMatcher } from '../common/invalid-error-state-matcher';
 import { SliderDemoComponent } from './slider-demo.component';
 
 @Injectable()
@@ -19,10 +21,6 @@ export class CustomErrorStateMatcher implements ErrorStateMatcher {
     return !!(control && control.invalid);
   }
 }
-
-import { DemoPsFormsService } from '../common/demo-ps-form-service';
-import { InvalidErrorStateMatcher } from '../common/invalid-error-state-matcher';
-import { SliderDemoComponent } from './slider-demo.component';
 
 @NgModule({
   declarations: [SliderDemoComponent],


### PR DESCRIPTION
When a load data request was already in flight and updateData was called with forceReload false,
then the data loading was incorrectly cancelled