### PR TITLE
refactor(form-field): alignment fixes removed (must ne done outside now)

### DIFF
--- a/projects/components/form-field/src/form-field.component.scss
+++ b/projects/components/form-field/src/form-field.component.scss
@@ -21,64 +21,13 @@ ps-form-field .mat-form-field-invalid .mat-slider-thumb {
 }
 */
 
+// Centers suffix icons for appearances other than legacy
 .mat-form-field:not(.mat-form-field-appearance-legacy) .mat-form-field-suffix {
   display: flex;
   align-items: center;
 }
 
-// Legacy appearance modifications
-.ps-form-field-type-mat-slider .mat-form-field-appearance-legacy mat-slider {
-  margin: -0.5em 0;
-  width: 100%;
-}
-.ps-form-field-type-mat-radio-group .mat-form-field-appearance-legacy .mat-form-field-infix {
-  padding: 0.36em 0;
-}
-.ps-form-field-type-mat-checkbox .mat-form-field-appearance-legacy .mat-form-field-infix {
-  padding: 0.25em 0;
-}
-
-// Standard appearance modifications
-.ps-form-field-type-mat-slider .mat-form-field-appearance-standard mat-slider {
-  margin: -0.435em 0;
-  width: 100%;
-}
-.ps-form-field-type-mat-radio-group .mat-form-field-appearance-standard .mat-form-field-infix {
-  padding: 0.42em 0;
-}
-.ps-form-field-type-mat-checkbox .mat-form-field-appearance-standard .mat-form-field-infix {
-  padding: 0.315em 0;
-}
-
-// Fill appearance modifications
-.ps-form-field-type-mat-slider .mat-form-field-appearance-fill mat-slider {
-  margin: -0.435em 0;
-  width: 100%;
-}
-.ps-form-field-type-mat-radio-group .mat-form-field-appearance-fill .mat-form-field-infix {
-  padding: 0.42em 0;
-}
-.ps-form-field-type-mat-checkbox .mat-form-field-appearance-fill .mat-form-field-infix {
-  padding: 0.31em 0;
-}
-
-// Outline appearance modifications
-.ps-form-field-type-mat-slider .mat-form-field-appearance-outline mat-slider {
-  margin: 0.06em 0;
-  width: 100%;
-}
-.ps-form-field-type-mat-radio-group .mat-form-field-appearance-outline .mat-form-field-infix {
-  padding: 0.92em 0;
-}
-.ps-form-field-type-mat-checkbox .mat-form-field-appearance-outline .mat-form-field-infix {
-  padding: 0.81em 0;
-}
-
-.ps-form-field-type-mat-slider .mat-form-field-infix {
-  padding: 0;
-}
-
-/* Mehrzeilige errors/hints erlauben */
+/* Allow multiline errors/hints */
 .ps-form-field--subscript-resize .mat-form-field-underline,
 .ps-form-field--subscript-resize .mat-form-field-subscript-wrapper {
   position: static;

--- a/projects/components/select/src/select.component.scss
+++ b/projects/components/select/src/select.component.scss
@@ -4,3 +4,9 @@
 .ps-select__error-message {
   color: red;
 }
+
+ngx-mat-select-search .mat-select-search-clear {
+  line-height: 1;
+  width: 2.5em;
+  height: 2.5em;
+}

--- a/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.html
+++ b/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.html
@@ -1,0 +1,352 @@
+<div>
+  <div>
+    <h2>Appearances</h2>
+    For more detail please visit
+    <a href="https://material.angular.io/components/form-field/overview#form-field-appearance-variants"
+      >https://material.angular.io/components/form-field/overview#form-field-appearance-variants</a
+    >
+    <ps-form-field style="margin: 0.5em;" [appearance]="'legacy'" [hint]="'hint text'">
+      <mat-label>Legacy</mat-label>
+      <input matInput type="text" />
+    </ps-form-field>
+    <ps-form-field style="margin: 0.5em;" [appearance]="'standard'" [hint]="'hint text'">
+      <mat-label>Standard</mat-label>
+      <input matInput type="text" />
+    </ps-form-field>
+    <ps-form-field style="margin: 0.5em;" [appearance]="'fill'" [hint]="'hint text'">
+      <mat-label>Fill</mat-label>
+      <input matInput type="text" />
+    </ps-form-field>
+    <ps-form-field style="margin: 0.5em;" [appearance]="'outline'" [hint]="'hint text'">
+      <mat-label>Outline</mat-label>
+      <input matInput type="text" />
+    </ps-form-field>
+
+    <h2>No form binding and no hint</h2>
+    <ps-form-field>
+      <mat-label>Referenz Column</mat-label>
+      <input matInput type="text" />
+    </ps-form-field>
+
+    <h2>No form binding and no MatFormFieldControl</h2>
+    <ps-form-field [hint]="'hint text'">
+      <mat-label>Referenz Column</mat-label>
+      <input type="text" />
+    </ps-form-field>
+
+    <h2>NgModel</h2>
+    <ps-form-field [hint]="'hint text'">
+      <mat-label>Referenz Column</mat-label>
+      <input matInput type="text" [(ngModel)]="value" />
+    </ps-form-field>
+
+    <h2>NgModel without MatFormFieldControl</h2>
+    <ps-form-field [hint]="'hint text'">
+      <mat-label>Referenz Column</mat-label>
+      <input type="text" [(ngModel)]="value" />
+    </ps-form-field>
+  </div>
+  <div>
+    <h2>Different controls</h2>
+    <mat-checkbox [(ngModel)]="disabled" style="margin: 0.5em;">disabled</mat-checkbox>
+    <mat-checkbox [(ngModel)]="customLabel" style="margin: 0.5em;">custom label</mat-checkbox>
+    <mat-checkbox [(ngModel)]="error" style="margin: 0.5em;">error</mat-checkbox>
+    <mat-checkbox [(ngModel)]="hintToggle" style="margin: 0.5em;">hint toggle button</mat-checkbox>
+    <mat-form-field style="margin: 0.5em;">
+      <mat-label>subscriptType</mat-label>
+      <mat-select [(ngModel)]="subscriptType">
+        <mat-option [value]="'single-line'">material default</mat-option>
+        <mat-option [value]="'resize'">auto height</mat-option>
+        <mat-option [value]="'bubble'">bubble</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field style="margin: 0.5em;">
+      <mat-label>appearance</mat-label>
+      <mat-select [(ngModel)]="appearance">
+        <mat-option [value]="'legacy'">legacy</mat-option>
+        <mat-option [value]="'standard'">standard</mat-option>
+        <mat-option [value]="'fill'">fill</mat-option>
+        <mat-option [value]="'outline'">outline</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field style="margin: 0.5em;">
+      <mat-label>hint text</mat-label>
+      <input type="text" matInput [(ngModel)]="hintText" />
+    </mat-form-field>
+    <mat-checkbox [(ngModel)]="showControls" style="margin: 0.5em;">Show controls</mat-checkbox>
+    <ul>
+      <li>
+        Checkbox can't dynamically switch from/to custom label, therefore both are shown separate below.
+      </li>
+      <li>
+        The reference columns are to make sure all controls have the same height and line up correctly.
+      </li>
+      <li>
+        Use the following style to align the heights of checkboxes, radio groups and sliders for the selected appearance. <br />
+        CSS rules may need adjustments if you do not use the default material typography.
+        <ng-container [ngSwitch]="appearance">
+          <pre *ngSwitchCase="'legacy'">
+            {{
+              '
+.ps-form-field-type-mat-slider .mat-form-field-appearance-legacy mat-slider {
+  margin: -0.5em 0;
+  width: 100%;
+}
+.ps-form-field-type-mat-radio-group .mat-form-field-appearance-legacy .mat-form-field-infix {
+  padding: 0.36em 0;
+}
+.ps-form-field-type-mat-checkbox .mat-form-field-appearance-legacy .mat-form-field-infix {
+  padding: 0.25em 0;
+}
+
+.ps-form-field-type-mat-slider .mat-form-field-infix {
+  padding: 0;
+}
+              '
+            }}
+          </pre>
+          <pre *ngSwitchCase="'standard'">
+            {{
+              '
+.ps-form-field-type-mat-slider .mat-form-field-appearance-standard mat-slider {
+  margin: -0.435em 0;
+  width: 100%;
+}
+.ps-form-field-type-mat-radio-group .mat-form-field-appearance-standard .mat-form-field-infix {
+  padding: 0.42em 0;
+}
+.ps-form-field-type-mat-checkbox .mat-form-field-appearance-standard .mat-form-field-infix {
+  padding: 0.315em 0;
+}
+
+.ps-form-field-type-mat-slider .mat-form-field-infix {
+  padding: 0;
+}
+              '
+            }}
+          </pre>
+          <pre *ngSwitchCase="'fill'">
+            {{
+              '
+.ps-form-field-type-mat-slider .mat-form-field-appearance-fill mat-slider {
+  margin: -0.435em 0;
+  width: 100%;
+}
+.ps-form-field-type-mat-radio-group .mat-form-field-appearance-fill .mat-form-field-infix {
+  padding: 0.42em 0;
+}
+.ps-form-field-type-mat-checkbox .mat-form-field-appearance-fill .mat-form-field-infix {
+  padding: 0.31em 0;
+}
+
+.ps-form-field-type-mat-slider .mat-form-field-infix {
+  padding: 0;
+}
+              '
+            }}
+          </pre>
+          <pre *ngSwitchCase="'outline'">
+            {{
+              '
+.ps-form-field-type-mat-slider .mat-form-field-appearance-outline mat-slider {
+  margin: 0.06em 0;
+  width: 100%;
+}
+.ps-form-field-type-mat-radio-group .mat-form-field-appearance-outline .mat-form-field-infix {
+  padding: 0.92em 0;
+}
+.ps-form-field-type-mat-checkbox .mat-form-field-appearance-outline .mat-form-field-infix {
+  padding: 0.81em 0;
+}
+
+.ps-form-field-type-mat-slider .mat-form-field-infix {
+  padding: 0;
+}
+              '
+            }}
+          </pre>
+        </ng-container>
+      </li>
+    </ul>
+  </div>
+  <div
+    *ngIf="showControls"
+    [formGroup]="form"
+    style="display: grid; grid-template-columns: repeat(6, min-content); grid-auto-rows: min-content; grid-gap: 5px;"
+  >
+    <div>Referenz Column</div>
+    <div>Control Column</div>
+    <div>Referenz Column</div>
+    <div>Control Column</div>
+    <div>Referenz Column</div>
+    <div>Control Column</div>
+    <div>
+      <div *ngFor="let i of ctrlCountNumbers">
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+    </div>
+    <div>
+      <div>
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+      <div>
+        <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
+          <mat-label *ngIf="customLabel">Custom Label</mat-label>
+          <mat-select formControlName="Select">
+            <mat-option [value]="null"><i>keine Auswahl</i></mat-option>
+            <mat-option value="item_ok">Ok</mat-option>
+            <mat-option value="item_error">Error</mat-option>
+          </mat-select>
+        </ps-form-field>
+      </div>
+      <div>
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+      <div>
+        <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
+          <mat-label *ngIf="customLabel">Custom Label</mat-label>
+          <mat-icon matPrefix class="app-form-example__icon">home</mat-icon>
+          <input matInput formControlName="Prefix_Text" type="text" />
+          <mat-icon matSuffix class="app-form-example__icon">phone</mat-icon>
+        </ps-form-field>
+      </div>
+      <div>
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+      <div>
+        <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
+          <mat-label *ngIf="customLabel">Custom Label</mat-label>
+          <mat-slider formControlName="Slider"></mat-slider>
+        </ps-form-field>
+      </div>
+      <div>
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+    </div>
+    <div>
+      <div *ngFor="let i of ctrlCountNumbers">
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+    </div>
+    <div>
+      <div>
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+      <div>
+        <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
+          <mat-checkbox formControlName="Checkbox"></mat-checkbox>
+        </ps-form-field>
+      </div>
+      <div>
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+      <div>
+        <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
+          <mat-checkbox formControlName="Checkbox">{{ asyncLabel$ | async }}</mat-checkbox>
+        </ps-form-field>
+      </div>
+      <div>
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+      <div>
+        <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
+          <mat-label *ngIf="customLabel">Custom Label</mat-label>
+          <mat-radio-group formControlName="Radio" style="display: flex; place-content: end space-between;">
+            <mat-radio-button [value]="true" style="padding-right: 8px;">Ja</mat-radio-button>
+            <mat-radio-button [value]="false" style="padding-right: 8px;">Nein</mat-radio-button>
+            <button
+              mat-icon-button
+              [disabled]="form.get('Radio').disabled || form.get('Radio').value === null"
+              (click)="form.get('Radio').patchValue(null)"
+              style="height: 20px; width: 20px; line-height: 20px;"
+            >
+              <mat-icon style="line-height: 20px;">clear</mat-icon>
+            </button>
+          </mat-radio-group>
+        </ps-form-field>
+      </div>
+      <div>
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+    </div>
+    <div>
+      <div *ngFor="let i of ctrlCountNumbers">
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+    </div>
+    <div>
+      <div>
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
+      <div>
+        <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
+          <mat-label *ngIf="customLabel">Custom Label</mat-label>
+          <ps-select
+            formControlName="PsSelect"
+            [dataSource]="{ mode: 'id', idKey: 'key', labelKey: 'label', items: psSelectData }"
+          ></ps-select>
+        </ps-form-field>
+      </div>
+    </div>
+  </div>
+</div>

--- a/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.scss
+++ b/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.scss
@@ -1,0 +1,51 @@
+// Legacy appearance modifications
+.ps-form-field-type-mat-slider .mat-form-field-appearance-legacy mat-slider {
+  margin: -0.5em 0;
+  width: 100%;
+}
+.ps-form-field-type-mat-radio-group .mat-form-field-appearance-legacy .mat-form-field-infix {
+  padding: 0.36em 0;
+}
+.ps-form-field-type-mat-checkbox .mat-form-field-appearance-legacy .mat-form-field-infix {
+  padding: 0.25em 0;
+}
+
+// Standard appearance modifications
+.ps-form-field-type-mat-slider .mat-form-field-appearance-standard mat-slider {
+  margin: -0.435em 0;
+  width: 100%;
+}
+.ps-form-field-type-mat-radio-group .mat-form-field-appearance-standard .mat-form-field-infix {
+  padding: 0.42em 0;
+}
+.ps-form-field-type-mat-checkbox .mat-form-field-appearance-standard .mat-form-field-infix {
+  padding: 0.315em 0;
+}
+
+// Fill appearance modifications
+.ps-form-field-type-mat-slider .mat-form-field-appearance-fill mat-slider {
+  margin: -0.435em 0;
+  width: 100%;
+}
+.ps-form-field-type-mat-radio-group .mat-form-field-appearance-fill .mat-form-field-infix {
+  padding: 0.42em 0;
+}
+.ps-form-field-type-mat-checkbox .mat-form-field-appearance-fill .mat-form-field-infix {
+  padding: 0.31em 0;
+}
+
+// Outline appearance modifications
+.ps-form-field-type-mat-slider .mat-form-field-appearance-outline mat-slider {
+  margin: 0.06em 0;
+  width: 100%;
+}
+.ps-form-field-type-mat-radio-group .mat-form-field-appearance-outline .mat-form-field-infix {
+  padding: 0.92em 0;
+}
+.ps-form-field-type-mat-checkbox .mat-form-field-appearance-outline .mat-form-field-infix {
+  padding: 0.81em 0;
+}
+
+.ps-form-field-type-mat-slider .mat-form-field-infix {
+  padding: 0;
+}

--- a/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.ts
+++ b/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.ts
@@ -23,241 +23,8 @@ export class ReferenceColumnComponent {
 
 @Component({
   selector: 'app-form-field-demo',
-  template: `
-    <div>
-      <div>
-        <h2>Appearances</h2>
-        For more detail please visit
-        <a href="https://material.angular.io/components/form-field/overview#form-field-appearance-variants"
-          >https://material.angular.io/components/form-field/overview#form-field-appearance-variants</a
-        >
-        <ps-form-field style="margin: .5em;" [appearance]="'legacy'" [hint]="'hint text'">
-          <mat-label>Legacy</mat-label>
-          <input matInput type="text" />
-        </ps-form-field>
-        <ps-form-field style="margin: .5em;" [appearance]="'standard'" [hint]="'hint text'">
-          <mat-label>Standard</mat-label>
-          <input matInput type="text" />
-        </ps-form-field>
-        <ps-form-field style="margin: .5em;" [appearance]="'fill'" [hint]="'hint text'">
-          <mat-label>Fill</mat-label>
-          <input matInput type="text" />
-        </ps-form-field>
-        <ps-form-field style="margin: .5em;" [appearance]="'outline'" [hint]="'hint text'">
-          <mat-label>Outline</mat-label>
-          <input matInput type="text" />
-        </ps-form-field>
-
-        <h2>No form binding and no hint</h2>
-        <ps-form-field>
-          <mat-label>Referenz Column</mat-label>
-          <input matInput type="text" />
-        </ps-form-field>
-
-        <h2>No form binding and no MatFormFieldControl</h2>
-        <ps-form-field [hint]="'hint text'">
-          <mat-label>Referenz Column</mat-label>
-          <input type="text" />
-        </ps-form-field>
-
-        <h2>NgModel</h2>
-        <ps-form-field [hint]="'hint text'">
-          <mat-label>Referenz Column</mat-label>
-          <input matInput type="text" [(ngModel)]="value" />
-        </ps-form-field>
-
-        <h2>NgModel without MatFormFieldControl</h2>
-        <ps-form-field [hint]="'hint text'">
-          <mat-label>Referenz Column</mat-label>
-          <input type="text" [(ngModel)]="value" />
-        </ps-form-field>
-      </div>
-      <div>
-        <h2>Different controls</h2>
-        <mat-checkbox [(ngModel)]="disabled" style="margin: .5em;">disabled</mat-checkbox>
-        <mat-checkbox [(ngModel)]="customLabel" style="margin: .5em;">custom label</mat-checkbox>
-        <mat-checkbox [(ngModel)]="error" style="margin: .5em;">error</mat-checkbox>
-        <mat-checkbox [(ngModel)]="hintToggle" style="margin: .5em;">hint toggle button</mat-checkbox>
-        <mat-form-field style="margin: .5em;">
-          <mat-label>subscriptType</mat-label>
-          <mat-select [(ngModel)]="subscriptType">
-            <mat-option [value]="'single-line'">material default</mat-option>
-            <mat-option [value]="'resize'">auto height</mat-option>
-            <mat-option [value]="'bubble'">bubble</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field style="margin: .5em;">
-          <mat-label>appearance</mat-label>
-          <mat-select [(ngModel)]="appearance">
-            <mat-option [value]="'legacy'">legacy</mat-option>
-            <mat-option [value]="'standard'">standard</mat-option>
-            <mat-option [value]="'fill'">fill</mat-option>
-            <mat-option [value]="'outline'">outline</mat-option>
-          </mat-select>
-        </mat-form-field>
-        <mat-form-field style="margin: .5em;">
-          <mat-label>hint text</mat-label>
-          <input type="text" matInput [(ngModel)]="hintText" />
-        </mat-form-field>
-        <ul>
-          <li>
-            Checkbox can't dynamically switch from/to custom label, therefore both are shown separate below.
-          </li>
-          <li>
-            The reference columns are to make sure all controls have the same height and line up correctly.
-          </li>
-        </ul>
-      </div>
-      <div
-        [formGroup]="form"
-        style="display: grid; grid-template-columns: repeat(4, min-content); grid-auto-rows: min-content; grid-gap: 5px;"
-      >
-        <div>Referenz Column</div>
-        <div>Control Column</div>
-        <div>Referenz Column</div>
-        <div>Control Column</div>
-        <div>
-          <div *ngFor="let i of ctrlCountNumbers">
-            <app-reference-column
-              [appearance]="appearance"
-              [hint]="hintText"
-              [hintToggle]="hintToggle"
-              [subscriptType]="subscriptType"
-            ></app-reference-column>
-          </div>
-        </div>
-        <div>
-          <div>
-            <app-reference-column
-              [appearance]="appearance"
-              [hint]="hintText"
-              [hintToggle]="hintToggle"
-              [subscriptType]="subscriptType"
-            ></app-reference-column>
-          </div>
-          <div>
-            <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
-              <mat-label *ngIf="customLabel">Custom Label</mat-label>
-              <mat-select formControlName="Select">
-                <mat-option [value]="null"><i>keine Auswahl</i></mat-option>
-                <mat-option value="item_ok">Ok</mat-option>
-                <mat-option value="item_error">Error</mat-option>
-              </mat-select>
-            </ps-form-field>
-          </div>
-          <div>
-            <app-reference-column
-              [appearance]="appearance"
-              [hint]="hintText"
-              [hintToggle]="hintToggle"
-              [subscriptType]="subscriptType"
-            ></app-reference-column>
-          </div>
-          <div>
-            <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
-              <mat-label *ngIf="customLabel">Custom Label</mat-label>
-              <mat-icon matPrefix class="app-form-example__icon">home</mat-icon>
-              <input matInput formControlName="Prefix_Text" type="text" />
-              <mat-icon matSuffix class="app-form-example__icon">phone</mat-icon>
-            </ps-form-field>
-          </div>
-          <div>
-            <app-reference-column
-              [appearance]="appearance"
-              [hint]="hintText"
-              [hintToggle]="hintToggle"
-              [subscriptType]="subscriptType"
-            ></app-reference-column>
-          </div>
-          <div>
-            <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
-              <mat-label *ngIf="customLabel">Custom Label</mat-label>
-              <mat-slider formControlName="Slider"></mat-slider>
-            </ps-form-field>
-          </div>
-          <div>
-            <app-reference-column
-              [appearance]="appearance"
-              [hint]="hintText"
-              [hintToggle]="hintToggle"
-              [subscriptType]="subscriptType"
-            ></app-reference-column>
-          </div>
-        </div>
-        <div>
-          <div *ngFor="let i of ctrlCountNumbers">
-            <app-reference-column
-              [appearance]="appearance"
-              [hint]="hintText"
-              [hintToggle]="hintToggle"
-              [subscriptType]="subscriptType"
-            ></app-reference-column>
-          </div>
-        </div>
-        <div>
-          <div>
-            <app-reference-column
-              [appearance]="appearance"
-              [hint]="hintText"
-              [hintToggle]="hintToggle"
-              [subscriptType]="subscriptType"
-            ></app-reference-column>
-          </div>
-          <div>
-            <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
-              <mat-checkbox formControlName="Checkbox"></mat-checkbox>
-            </ps-form-field>
-          </div>
-          <div>
-            <app-reference-column
-              [appearance]="appearance"
-              [hint]="hintText"
-              [hintToggle]="hintToggle"
-              [subscriptType]="subscriptType"
-            ></app-reference-column>
-          </div>
-          <div>
-            <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
-              <mat-checkbox formControlName="Checkbox">{{ asyncLabel$ | async }}</mat-checkbox>
-            </ps-form-field>
-          </div>
-          <div>
-            <app-reference-column
-              [appearance]="appearance"
-              [hint]="hintText"
-              [hintToggle]="hintToggle"
-              [subscriptType]="subscriptType"
-            ></app-reference-column>
-          </div>
-          <div>
-            <ps-form-field [appearance]="appearance" [hint]="hintText" [hintToggle]="hintToggle" [subscriptType]="subscriptType">
-              <mat-label *ngIf="customLabel">Custom Label</mat-label>
-              <mat-radio-group formControlName="Radio" style="display: flex;place-content: end space-between;">
-                <mat-radio-button [value]="true" style="padding-right: 8px;">Ja</mat-radio-button>
-                <mat-radio-button [value]="false" style="padding-right: 8px;">Nein</mat-radio-button>
-                <button
-                  mat-icon-button
-                  [disabled]="form.get('Radio').disabled || form.get('Radio').value === null"
-                  (click)="form.get('Radio').patchValue(null)"
-                  style="height:20px;width:20px;line-height:20px"
-                >
-                  <mat-icon style="line-height: 20px;">clear</mat-icon>
-                </button>
-              </mat-radio-group>
-            </ps-form-field>
-          </div>
-          <div>
-            <app-reference-column
-              [appearance]="appearance"
-              [hint]="hintText"
-              [hintToggle]="hintToggle"
-              [subscriptType]="subscriptType"
-            ></app-reference-column>
-          </div>
-        </div>
-      </div>
-    </div>
-  `,
+  templateUrl: './form-field-demo.component.html',
+  styleUrls: ['./form-field-demo.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
@@ -312,13 +79,21 @@ export class FormFieldDemoComponent {
   }
 
   public form = new FormGroup({
-    Text: new FormControl(''),
-    Select: new FormControl(''),
-    Checkbox: new FormControl(''),
-    Radio: new FormControl(''),
-    Prefix_Text: new FormControl(''),
-    Slider: new FormControl(''),
+    Text: new FormControl(null),
+    Select: new FormControl(null),
+    Checkbox: new FormControl(null),
+    Radio: new FormControl(null),
+    Prefix_Text: new FormControl(null),
+    Slider: new FormControl(null),
+    PsSelect: new FormControl(null),
   });
+
+  public showControls = true;
+  public psSelectData = [
+    { key: 1, label: 'Option 1' },
+    { key: 2, label: 'Option 2' },
+    { key: 3, label: 'Option 3' },
+  ];
 
   private _disabled = false;
   private _error = false;

--- a/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.module.ts
+++ b/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.module.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { NgModule, Injectable } from '@angular/core';
+import { Injectable, NgModule } from '@angular/core';
 import { FormControl, FormGroupDirective, FormsModule, NgForm, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -13,6 +13,7 @@ import { MatSliderModule } from '@angular/material/slider';
 import { RouterModule } from '@angular/router';
 import { PsFormBaseModule } from '@prosoft/components/form-base';
 import { PsFormFieldModule } from '@prosoft/components/form-field';
+import { DefaultPsSelectService, PsSelectModule } from '@prosoft/components/select';
 import { DemoPsFormsService } from '../common/demo-ps-form-service';
 import { InvalidErrorStateMatcher } from '../common/invalid-error-state-matcher';
 import { FormFieldDemoComponent, ReferenceColumnComponent } from './form-field-demo.component';
@@ -31,6 +32,7 @@ export class CustomErrorStateMatcher implements ErrorStateMatcher {
     CommonModule,
     PsFormBaseModule.forRoot(DemoPsFormsService),
     PsFormFieldModule,
+    PsSelectModule.forRoot(DefaultPsSelectService),
     RouterModule.forChild([
       {
         path: '',

--- a/projects/prosoft-components-demo/src/styles.scss
+++ b/projects/prosoft-components-demo/src/styles.scss
@@ -1,4 +1,52 @@
-@import '@angular/material/prebuilt-themes/deeppurple-amber.css';
+//==========================================
+//= Font Import
+//==========================================
+// Ohne das ":light,regular,medium,thin,italic,mediumitalic,bold" ist die Schrift teils unscharf
+// @import url('https://fonts.googleapis.com/css?family=Quicksand:light,regular,medium,thin,italic,mediumitalic,bold');
+
+// ==========================================
+// = Material Theme Generierung
+// ==========================================
+@import '~@angular/material/theming';
+
+// Define the typography map
+// Name             CSS classes                         Description
+// display-4	    .mat-display-4	                    Large, one-off header, usually at the top of the page (e.g. a hero header).
+// display-3	    .mat-display-3	                    Large, one-off header, usually at the top of the page (e.g. a hero header).
+// display-2	    .mat-display-2	                    Large, one-off header, usually at the top of the page (e.g. a hero header).
+// display-1	    .mat-display-1	                    Large, one-off header, usually at the top of the page (e.g. a hero header).
+// headline	        .mat-h1, .mat-headline	            Section heading corresponding to the <h1> tag.
+// title	        .mat-h2, .mat-title	                Section heading corresponding to the <h2> tag.
+// subheading-2	    .mat-h3, .mat-subheading-2	        Section heading corresponding to the <h3> tag.
+// subheading-1	    .mat-h4, .mat-subheading-1	        Section heading corresponding to the <h4> tag.
+// body-1	        .mat-body, .mat-body-1	            Base body text.
+// body-2	        .mat-body-strong, .mat-body-2	    Bolder body text.
+// caption	        .mat-small, .mat-caption	        Smaller body and hint text.
+// button	        None. Used only in components.	    Buttons and anchors.
+// input	        None. Used only in components.	    Form input fields. Line-height must be unit-less fraction of the font-size.
+$general-typography: mat-typography-config() !default;
+
+// Include the common styles for Angular Material. We include this here so that you only
+// have to load a single css file for Angular Material in your app.
+// **Be sure that you only ever include this mixin once!**
+@include mat-core($general-typography);
+
+// Define the palettes for your theme using the Material Design palettes available in palette.scss
+// (imported above). For each palette, you can optionally specify a default, lighter, and darker
+// hue. Available color palettes: https://material.io/design/color/
+$base-app-primary: mat-palette($mat-indigo);
+$base-app-accent: mat-palette($mat-pink, A200, A100, A400);
+
+// The warn palette is optional (defaults to red).
+$base-app-warn: mat-palette($mat-red);
+
+// Create the theme object (a Sass map containing all of the palettes).
+$base-app-theme: mat-light-theme($base-app-primary, $base-app-accent, $base-app-warn);
+
+// Include theme styles for core and each component used in your app.
+// Alternatively, you can import and @include the theme mixins for each component
+// that you are using.
+@include angular-material-theme($base-app-theme);
 
 html,
 body {


### PR DESCRIPTION
Alignment fixes for appearance 'legacy' removed.
Alignment fix examples for all appearances added to demo page (working for default material typography).
Fixed a sizing bug of the selectbox clear button

BREAKING CHANGE: Appearance fixes must now be defined outside now