### PR TITLE
fix(select): outline gap calculated correctly with ps-select

### DIFF
--- a/projects/components/form-field/src/form-field.component.ts
+++ b/projects/components/form-field/src/form-field.component.ts
@@ -1,6 +1,6 @@
+import type { QueryList } from '@angular/core';
 import {
   AfterContentInit,
-  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   ContentChild,
@@ -32,10 +32,8 @@ import {
 import { hasRequiredField, IPsFormError, PsFormService } from '@prosoft/components/form-base';
 import { Observable, of, Subscription } from 'rxjs';
 import { tap } from 'rxjs/operators';
-
 import { DummyMatFormFieldControl } from './dummy-mat-form-field-control';
 
-import type { QueryList } from '@angular/core';
 export declare type PsFormFieldSubscriptType = 'bubble' | 'resize' | 'single-line';
 
 export interface PsFormFieldConfig {
@@ -80,7 +78,7 @@ export const PS_FORM_FIELD_CONFIG = new InjectionToken<PsFormFieldConfig>('PS_FO
   changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
 })
-export class PsFormFieldComponent implements OnChanges, AfterContentInit, AfterViewInit, OnDestroy {
+export class PsFormFieldComponent implements OnChanges, AfterContentInit, OnDestroy {
   @Input() public createLabel = true;
   @Input() public floatLabel: FloatLabelType = this.matDefaults?.floatLabel || 'auto';
   @Input() public hint: string = null;
@@ -161,7 +159,6 @@ export class PsFormFieldComponent implements OnChanges, AfterContentInit, AfterV
   private hasError = false;
 
   private labelTextSubscription: Subscription;
-  private _afterViewInitTimeoutNumber: number;
 
   constructor(
     private _elementRef: ElementRef,
@@ -174,18 +171,6 @@ export class PsFormFieldComponent implements OnChanges, AfterContentInit, AfterV
         hintToggle: false,
         subscriptType: 'resize',
       };
-    }
-  }
-
-  public ngAfterViewInit(): void {
-    // Fixes a bug where the label of a ps-select is rendered too late which prevents the calculation of the outline gap.
-    // Only happens when the control is conditionally visible (ngIf, switch-Container, etc.)
-    // The first one who can fix this properly is eligible to get a free cookie :D
-    if (this.appearance === 'outline' && this.controlType === 'ps-select') {
-      this._afterViewInitTimeoutNumber = setTimeout(() => {
-        (<any>this._matFormField)._outlineGapCalculationNeededOnStable = true;
-        this._afterViewInitTimeoutNumber = null;
-      });
     }
   }
 
@@ -232,10 +217,6 @@ export class PsFormFieldComponent implements OnChanges, AfterContentInit, AfterV
 
     if (this.labelTextSubscription) {
       this.labelTextSubscription.unsubscribe();
-    }
-
-    if (this._afterViewInitTimeoutNumber) {
-      clearTimeout(this._afterViewInitTimeoutNumber);
     }
   }
 

--- a/projects/components/select/src/select.component.ts
+++ b/projects/components/select/src/select.component.ts
@@ -158,7 +158,7 @@ export class PsSelectComponent<T = unknown> extends _PsSelectMixinBase
   public empty = true;
 
   public get shouldLabelFloat() {
-    return this._matSelect.shouldLabelFloat;
+    return !this.empty;
   }
 
   public get focused() {

--- a/projects/prosoft-components-demo/src/app/app.module.ts
+++ b/projects/prosoft-components-demo/src/app/app.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { MAT_FORM_FIELD_DEFAULT_OPTIONS } from '@angular/material/form-field';
 import { MatListModule } from '@angular/material/list';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -21,52 +22,55 @@ import { AppComponent } from './app.component';
     RouterModule.forRoot([
       {
         path: 'flip-container',
-        loadChildren: () => import('./flip-container-demo/flip-container-demo.module').then(m => m.FlipContainerDemoModule),
+        loadChildren: () => import('./flip-container-demo/flip-container-demo.module').then((m) => m.FlipContainerDemoModule),
       },
       {
         path: 'select',
-        loadChildren: () => import('./select-demo/select-demo.module').then(m => m.SelectDemoModule),
+        loadChildren: () => import('./select-demo/select-demo.module').then((m) => m.SelectDemoModule),
       },
       {
         path: 'form-errors',
-        loadChildren: () => import('./form-errors-demo/form-errors-demo.module').then(m => m.FormErrorsDemoModule),
+        loadChildren: () => import('./form-errors-demo/form-errors-demo.module').then((m) => m.FormErrorsDemoModule),
       },
       {
         path: 'form-field',
-        loadChildren: () => import('./form-field-demo/form-field-demo.module').then(m => m.FormFieldDemoModule),
+        loadChildren: () => import('./form-field-demo/form-field-demo.module').then((m) => m.FormFieldDemoModule),
       },
       {
         path: 'savebar',
-        loadChildren: () => import('./savebar-demo/savebar-demo.module').then(m => m.SavebarDemoModule),
+        loadChildren: () => import('./savebar-demo/savebar-demo.module').then((m) => m.SavebarDemoModule),
       },
       {
         path: 'block-ui',
-        loadChildren: () => import('./block-ui-demo/block-ui-demo.module').then(m => m.BlockUiDemoModule),
+        loadChildren: () => import('./block-ui-demo/block-ui-demo.module').then((m) => m.BlockUiDemoModule),
       },
       {
         path: 'slider',
-        loadChildren: () => import('./slider-demo/slider-demo.module').then(m => m.SliderDemoModule),
+        loadChildren: () => import('./slider-demo/slider-demo.module').then((m) => m.SliderDemoModule),
       },
       {
         path: 'number-input',
-        loadChildren: () => import('./number-input-demo/number-input-demo.module').then(m => m.NumberInputDemoModule),
+        loadChildren: () => import('./number-input-demo/number-input-demo.module').then((m) => m.NumberInputDemoModule),
       },
       {
         path: 'form',
-        loadChildren: () => import('./form-demo/form-demo.module').then(m => m.FormDemoModule),
+        loadChildren: () => import('./form-demo/form-demo.module').then((m) => m.FormDemoModule),
       },
       {
         path: 'table',
-        loadChildren: () => import('./table-demo/table-demo.module').then(m => m.TableDemoModule),
+        loadChildren: () => import('./table-demo/table-demo.module').then((m) => m.TableDemoModule),
       },
       {
         path: '**',
         pathMatch: 'full',
-        loadChildren: () => import('./start-page/start-page.module').then(m => m.StartPageModule),
+        loadChildren: () => import('./start-page/start-page.module').then((m) => m.StartPageModule),
       },
     ]),
   ],
-  providers: [{ provide: PsIntlService, useClass: PsIntlServiceEn }],
+  providers: [
+    { provide: MAT_FORM_FIELD_DEFAULT_OPTIONS, useValue: { appearance: 'outline' } },
+    { provide: PsIntlService, useClass: PsIntlServiceEn },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.html
+++ b/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.html
@@ -347,6 +347,14 @@
           ></ps-select>
         </ps-form-field>
       </div>
+      <div>
+        <app-reference-column
+          [appearance]="appearance"
+          [hint]="hintText"
+          [hintToggle]="hintToggle"
+          [subscriptType]="subscriptType"
+        ></app-reference-column>
+      </div>
     </div>
   </div>
 </div>

--- a/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.ts
+++ b/projects/prosoft-components-demo/src/app/form-field-demo/form-field-demo.component.ts
@@ -32,7 +32,7 @@ export class FormFieldDemoComponent {
   public subscriptType: PsFormFieldSubscriptType = 'single-line';
   public hintToggle = false;
   public hintText = 'hint text';
-  public appearance: MatFormFieldAppearance = 'legacy';
+  public appearance: MatFormFieldAppearance = 'outline';
   public asyncLabel$ = of('Custom Label');
   public ctrlCountNumbers = Array(7).fill(1);
   public value = '';
@@ -80,12 +80,12 @@ export class FormFieldDemoComponent {
 
   public form = new FormGroup({
     Text: new FormControl(null),
-    Select: new FormControl(null),
+    Select: new FormControl('item_ok'),
     Checkbox: new FormControl(null),
     Radio: new FormControl(null),
     Prefix_Text: new FormControl(null),
     Slider: new FormControl(null),
-    PsSelect: new FormControl(null),
+    PsSelect: new FormControl(1),
   });
 
   public showControls = true;


### PR DESCRIPTION
The outline gap of a form field is now calculated correctly with a ps-select inside.
Default appearance of demo app changed to 'outline'