### PR TITLE
perf(table): paginating keeps rows while loading

### DIFF
--- a/docs/block-ui.md
+++ b/docs/block-ui.md
@@ -26,6 +26,7 @@ import { PsBlockUiModule } from '@prosoft/components/block-ui';
 | --------------------- | -------------------------------------------------------------------------------------------- |
 | `blocked: boolean`    | Toggles the blocking overlay. However, the blocked content is still accessable via keyboard. |
 | `spinnerText: string` | The text that will be shown under the blocking spinner.                                      |
+| `clickthrough: boolean` | Allows clicking through the blocking overlay.                                              |
 
 ---
 

--- a/projects/components/block-ui/src/block-ui.component.ts
+++ b/projects/components/block-ui/src/block-ui.component.ts
@@ -1,4 +1,13 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, Input, OnChanges, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  HostBinding,
+  Input,
+  OnChanges,
+  ViewChild,
+  ViewEncapsulation,
+} from '@angular/core';
 
 import type { ElementRef } from '@angular/core';
 
@@ -24,6 +33,14 @@ import type { ElementRef } from '@angular/core';
       ps-block-ui {
         display: grid;
         position: relative;
+      }
+
+      .ps-block-ui__clickthrough {
+        pointer-events: none;
+      }
+
+      .ps-block-ui__clickthrough > .ps-block-ui__content {
+        pointer-events: auto;
       }
 
       .ps-block-ui__content {
@@ -68,6 +85,9 @@ import type { ElementRef } from '@angular/core';
 export class PsBlockUiComponent implements OnChanges, AfterViewInit {
   @Input() public blocked: boolean;
   @Input() public spinnerText: string;
+  @HostBinding('class.ps-block-ui__clickthrough')
+  @Input()
+  public clickthrough = false;
 
   public spinnerDiameter = 100;
 

--- a/projects/components/table/src/data/table-data-source.ts
+++ b/projects/components/table/src/data/table-data-source.ts
@@ -149,9 +149,7 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
     this.listActions = options.actions?.filter((a) => a.scope & PsTableActionScope.list) || [];
     this._updateDataTrigger$ = options.loadTrigger$ || NEVER;
     this._loadData = options.loadDataFn;
-    this.moreMenuThreshold = options.moreMenuThreshold || 3;
-
-    this._initDataChangeSubscription();
+    this.moreMenuThreshold = options.moreMenuThreshold ?? 3;
   }
 
   /**
@@ -160,7 +158,7 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
    * on its data relative to the function to know if a row should be added/removed/moved.
    * Accepts a function that takes two parameters, index and item.
    */
-  public trackBy: TrackByFunction<T> = (_index, item) => item;
+  public trackBy: TrackByFunction<T> = (i) => i; // index is more performant than item reference when paginating
 
   /**
    * Returns the names of the property that should be used in filterPredicate.
@@ -313,7 +311,6 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
       this._loadDataSubscription.unsubscribe();
       this.error = null;
       this.loading = true;
-      this._renderData.next([]);
       this._internalDetectChanges.next();
 
       const updateInfo = this.getUpdateDataInfo(true);
@@ -369,6 +366,7 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
    * @docs-private
    */
   public connect() {
+    this._initDataChangeSubscription();
     this._updateDataTriggerSub = this._updateDataTrigger$.subscribe((data) => {
       this._lastLoadTriggerData = data;
       this.updateData();
@@ -381,6 +379,7 @@ export class PsTableDataSource<T, TTrigger = any> extends DataSource<T> {
    * @docs-private
    */
   public disconnect() {
+    this._renderChangesSubscription.unsubscribe();
     this._updateDataTriggerSub.unsubscribe();
     this._loadDataSubscription.unsubscribe();
   }

--- a/projects/components/table/src/table.component.html
+++ b/projects/components/table/src/table.component.html
@@ -16,7 +16,7 @@
       (searchChanged)="onSearchChanged($event)"
     ></ps-table-header>
 
-    <div [class.ps-table__shadow]="layout === 'card'">
+    <ps-block-ui [class.ps-table__shadow]="layout === 'card'" [blocked]="showLoading" [clickthrough]="true">
       <ps-table-data
         [intl]="intl"
         [dataSource]="dataSource"
@@ -35,9 +35,6 @@
 
       <div class="ps-table__no-entries-text" *ngIf="showNoEntriesText">{{ intl.noEntriesLabel }}</div>
       <div class="ps-table__error-text" *ngIf="showError">{{ errorMessage }}</div>
-      <div class="ps-table__loading-container" *ngIf="showLoading">
-        <mat-spinner class="ps-table__loading-spinner"></mat-spinner>
-      </div>
       <ps-table-pagination
         [pageSize]="pageSize"
         [dataLength]="dataLength"
@@ -47,7 +44,7 @@
         [pageDebounce]="pageDebounce"
         (page)="onPage($event)"
       ></ps-table-pagination>
-    </div>
+    </ps-block-ui>
   </div>
   <div *psFlipContainerBack>
     <ps-table-settings

--- a/projects/components/table/src/table.component.scss
+++ b/projects/components/table/src/table.component.scss
@@ -2,13 +2,8 @@ ps-table {
   display: block;
   border-radius: 4px;
 
-  .ps-table__loading-spinner {
-    margin: 1em auto;
-  }
-
   .ps-table__no-entries-text,
-  .ps-table__error-text,
-  .ps-table__loading-container {
+  .ps-table__error-text {
     font-size: large;
     background-color: white;
     padding: 1em 0;

--- a/projects/components/table/src/table.module.ts
+++ b/projects/components/table/src/table.module.ts
@@ -8,11 +8,11 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatPaginatorModule } from '@angular/material/paginator';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { PsBlockUiModule } from '@prosoft/components/block-ui';
 import { PsFlipContainerModule } from '@prosoft/components/flip-container';
 import { PsSavebarModule } from '@prosoft/components/savebar';
 import {
@@ -76,10 +76,10 @@ import { PsTableComponent } from './table.component';
     MatSelectModule,
     MatInputModule,
     MatCardModule,
-    MatProgressSpinnerModule,
     MatTooltipModule,
     PsFlipContainerModule,
     PsSavebarModule,
+    PsBlockUiModule,
   ],
   exports: [
     PsTableComponent,

--- a/projects/prosoft-components-demo/src/app/block-ui-demo/block-ui-demo.component.ts
+++ b/projects/prosoft-components-demo/src/app/block-ui-demo/block-ui-demo.component.ts
@@ -8,6 +8,19 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
       <mat-label>Text for the block ui</mat-label>
       <input type="text" matInput [(ngModel)]="spinnerText" />
     </mat-form-field>
+
+    <div style="height: 1em;"></div>
+    <ps-block-ui [blocked]="blocked" [clickthrough]="true">
+      <div>this block-ui is clickthrough</div>
+      <button type="button" mat-raised-button color="primary">clickable</button>
+    </ps-block-ui>
+
+    <div style="height: 1em;"></div>
+    <ps-block-ui [blocked]="blocked">
+      <div>this block-ui is NOT clickthrough</div>
+      <button type="button" mat-raised-button color="primary">NOT clickable while blocked</button>
+    </ps-block-ui>
+
     <div style="height: 1em;"></div>
     <div style="height: 50px; overflow: auto;">
       <ps-block-ui [blocked]="blocked">
@@ -16,6 +29,7 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
         </div>
       </ps-block-ui>
     </div>
+
     <div style="height: 1em;"></div>
     <div style="height: 50px; overflow: auto;">
       <ps-block-ui [blocked]="blocked" [spinnerText]="spinnerText">
@@ -24,18 +38,21 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
         </div>
       </ps-block-ui>
     </div>
+
     <div style="height: 1em;"></div>
     <ps-block-ui [blocked]="blocked" [spinnerText]="spinnerText">
       <mat-card>
         this will be blocked
       </mat-card>
     </ps-block-ui>
+
     <div style="height: 1em;"></div>
     <ps-block-ui [blocked]="blocked" [spinnerText]="spinnerText">
       <mat-card style="height: 30vh">
         this will also be blocked
       </mat-card>
     </ps-block-ui>
+
     <div style="height: 1em;"></div>
     <ps-block-ui [blocked]="blocked" [spinnerText]="spinnerText">
       <mat-card style="height: 300vh">

--- a/projects/prosoft-components-demo/src/app/block-ui-demo/block-ui-demo.module.ts
+++ b/projects/prosoft-components-demo/src/app/block-ui-demo/block-ui-demo.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -24,6 +25,7 @@ import { BlockUiDemoComponent } from './block-ui-demo.component';
     MatInputModule,
     MatFormFieldModule,
     MatCheckboxModule,
+    MatButtonModule,
   ],
   declarations: [BlockUiDemoComponent],
   providers: [],

--- a/projects/prosoft-components-demo/src/app/table-demo/table-demo.component.html
+++ b/projects/prosoft-components-demo/src/app/table-demo/table-demo.component.html
@@ -22,24 +22,28 @@
       <input matInput type="string" [(ngModel)]="caption" />
     </mat-form-field>
     <mat-form-field>
-      <mat-label>[dataSource]</mat-label>
-      <mat-select [(ngModel)]="dataSourceType" (selectionChange)="onDataSourceTypeChanged($event)">
-        <mat-option [value]="'client'">sample data (client filter/sort/paging)</mat-option>
-        <mat-option [value]="'error'">error while loading</mat-option>
-        <mat-option [value]="'loading'">endless loading</mat-option>
-        <mat-option [value]="'actions'">action definition</mat-option>
-        <mat-option [value]="'empty'">no data</mat-option>
-      </mat-select>
-    </mat-form-field>
-    <mat-form-field>
       <input matInput type="number" [(ngModel)]="pageDebounce" />
       <mat-label>Page debounce in ms</mat-label>
     </mat-form-field>
+    <div>[dataSource] = new PsTableDataSource(...)</div>
     <div>(page) $event = &#x7B; pageIndex: number; previousPageIndex?: number; pageSize: number; length: number; &#x7D;</div>
 
     <mat-checkbox [(ngModel)]="disableAllSortable" (change)="rebuildTable()"
       >set all ps-table-column [sortable]="false" and ps-table [sortDefinitions]="null"</mat-checkbox
     >
+  </mat-card>
+
+  <mat-card class="app-table-demo__settings-box">
+    <strong>PsTableDataSource</strong>
+    <mat-checkbox [(ngModel)]="dsThrowError" (change)="reloadTable()">throw error</mat-checkbox>
+    <mat-form-field>
+      <input matInput type="number" [(ngModel)]="dsLoadDelay" (change)="reloadTable()" />
+      <mat-label>loading delay in ms</mat-label>
+    </mat-form-field>
+    <mat-form-field>
+      <input matInput type="number" [(ngModel)]="dsDataCount" (change)="rebuildSampleData()" />
+      <mat-label>item count</mat-label>
+    </mat-form-field>
   </mat-card>
 
   <mat-card class="app-table-demo__settings-box">


### PR DESCRIPTION
The current rows are only overlayed with a loading spinner while loading the new page.
This prevents a complete removal and rebuild of the rows.