### PR TITLE
feat: add auto-form-array

### DIFF
--- a/projects/components/utils/public_api.ts
+++ b/projects/components/utils/public_api.ts
@@ -1,3 +1,4 @@
 export { objectToKeyValueArray } from './src/object';
 export { isInViewport } from './src/dom';
 export { replaceAll } from './src/string';
+export { AutoFormArray } from './src/auto-form-array';

--- a/projects/components/utils/src/auto-form-array.spec.ts
+++ b/projects/components/utils/src/auto-form-array.spec.ts
@@ -1,0 +1,89 @@
+import { FormControl, Validators } from '@angular/forms';
+import { of } from 'rxjs';
+import { AutoFormArray } from './auto-form-array';
+
+describe('AutoFormArray', () => {
+  it('should initialize FormArray when constructed', () => {
+    const asyncValidator = () => of(null);
+    const array = new AutoFormArray(() => new FormControl(''), Validators.required, asyncValidator);
+    expect(array.length).toEqual(0);
+    expect(array.validator).toEqual(Validators.required);
+    expect(array.asyncValidator).toEqual(asyncValidator);
+  });
+  it('should add subforms when resizeTo is called with a higher value than length', () => {
+    const array = new AutoFormArray(() => new FormControl(''));
+    array.push(new FormControl(0));
+
+    array.resizeTo(3);
+    expect(array.length).toBe(3);
+    expect(array.value).toEqual([0, '', '']);
+  });
+  it('should remove subforms when resizeTo is called with a lower value than length', () => {
+    const array = new AutoFormArray(() => new FormControl(''));
+    array.push(new FormControl(0));
+    array.push(new FormControl(1));
+    array.push(new FormControl(2));
+
+    array.resizeTo(2);
+    expect(array.length).toBe(2);
+    expect(array.value).toEqual([0, 1]);
+  });
+  it('should not modify subforms when resizeTo is called with same value than length', () => {
+    const array = new AutoFormArray(() => new FormControl(''));
+    array.push(new FormControl(0));
+    array.push(new FormControl(1));
+    array.push(new FormControl(2));
+
+    array.resizeTo(3);
+    expect(array.length).toBe(3);
+    expect(array.value).toEqual([0, 1, 2]);
+  });
+  it('should add subforms disabled if FormArray is disabled', () => {
+    const array = new AutoFormArray(() => new FormControl(''));
+    array.push(new FormControl(0));
+    array.disable();
+
+    array.resizeTo(3);
+    for (const ctrl of array.controls) {
+      expect(ctrl.disabled).toBeTruthy();
+    }
+  });
+  it('should add subforms enabled if FormArray is enabled', () => {
+    const array = new AutoFormArray(() => new FormControl(''));
+    array.push(new FormControl(0));
+
+    array.resizeTo(3);
+    for (const ctrl of array.controls) {
+      expect(ctrl.disabled).toBeFalsy();
+    }
+  });
+  it('should adjust number of subforms when patchValue is called', () => {
+    const array = new AutoFormArray(() => new FormControl(''));
+    spyOn(array, 'resizeTo').and.callThrough();
+
+    array.patchValue([0, 1, 2, 3]);
+
+    expect(array.resizeTo).toHaveBeenCalledWith(4);
+    expect(array.length).toBe(4);
+    expect(array.value).toEqual([0, 1, 2, 3]);
+  });
+  it('should adjust number of subforms when reset is called', () => {
+    const array = new AutoFormArray(() => new FormControl(''));
+    spyOn(array, 'resizeTo').and.callThrough();
+
+    array.reset([0, 1, 2, 3]);
+
+    expect(array.resizeTo).toHaveBeenCalledWith(4);
+    expect(array.length).toBe(4);
+    expect(array.value).toEqual([0, 1, 2, 3]);
+  });
+  it('should NOT adjust number of subforms when setValue is called', () => {
+    const array = new AutoFormArray(() => new FormControl(''));
+    spyOn(array, 'resizeTo').and.callThrough();
+
+    expect(() => array.setValue([0, 1, 2, 3])).toThrow();
+    expect(array.resizeTo).not.toHaveBeenCalled();
+    expect(array.length).toBe(0);
+    expect(array.value).toEqual([]);
+  });
+});

--- a/projects/components/utils/src/auto-form-array.ts
+++ b/projects/components/utils/src/auto-form-array.ts
@@ -1,0 +1,58 @@
+import { AbstractControl, AbstractControlOptions, AsyncValidatorFn, FormArray, ValidatorFn } from '@angular/forms';
+
+export class AutoFormArray extends FormArray {
+  /**
+   * Creates a new `FormArray` instance.
+   *
+   * @param controlGenerator A function that generates the control for en entry.
+   *
+   * @param validatorOrOpts A synchronous validator function, or an array of
+   * such functions, or an `AbstractControlOptions` object that contains validation functions
+   * and a validation trigger.
+   *
+   * @param asyncValidator A single async validator or array of async validator functions
+   *
+   */
+  constructor(
+    private controlGenerator: () => AbstractControl,
+    validatorOrOpts?: ValidatorFn | ValidatorFn[] | AbstractControlOptions | null,
+    asyncValidator?: AsyncValidatorFn | AsyncValidatorFn[] | null
+  ) {
+    super([], validatorOrOpts, asyncValidator);
+  }
+
+  public override patchValue(
+    value: unknown[],
+    options?: {
+      onlySelf?: boolean;
+      emitEvent?: boolean;
+    }
+  ): void {
+    this.resizeTo(value ? value.length : 0);
+    return super.patchValue(value, options);
+  }
+
+  public override reset(
+    value?: { length: number },
+    options?: {
+      onlySelf?: boolean;
+      emitEvent?: boolean;
+    }
+  ): void {
+    this.resizeTo(value ? value.length : 0);
+    return super.reset(value, options);
+  }
+
+  public resizeTo(length: number) {
+    while (this.length < length) {
+      const newForm = this.controlGenerator();
+      if (this.disabled) {
+        newForm.disable();
+      }
+      this.push(newForm);
+    }
+    while (this.length > length) {
+      this.removeAt(this.length - 1);
+    }
+  }
+}


### PR DESCRIPTION
Add Benedikts form array extension auto-resizes on patchValue.
This includes some small changes to the original code to adhere to
our linter standards, here is the gist of it:
```
--- a/./projects/components/utils/src/auto-form-array.ts
+++ b/original_auto-form-array.ts
@@ -21,8 +21,8 @@ export class AutoFormArray extends FormArray {
         super([], validatorOrOpts, asyncValidator);
     }

-  public override patchValue(
-    value: unknown[],
+    public patchValue(
+        value: any[],
         options?: {
             onlySelf?: boolean;
             emitEvent?: boolean;
@@ -32,8 +32,8 @@ export class AutoFormArray extends FormArray {
         return super.patchValue(value, options);
     }

-  public override reset(
-    value?: { length: number },
+    public reset(
+        value?: any,
         options?: {
             onlySelf?: boolean;
             emitEvent?: boolean;
```